### PR TITLE
Display all authors

### DIFF
--- a/ckanext/nhm/lib/helpers.py
+++ b/ckanext/nhm/lib/helpers.py
@@ -780,7 +780,7 @@ def dataset_author_truncate(author_str):
             # Otherwise use the jinja truncate function (may split author name)
             shortened = do_truncate(author_str, length=AUTHOR_MAX_LENGTH, end='')
 
-        return literal('%s <abbr title="%s">et al.</abbr>' % (shortened, author_str))
+        return literal('{0} <abbr title="{1}">et al.</abbr>'.format(shortened, author_str))
 
     if len(author_str) > AUTHOR_MAX_LENGTH:
 

--- a/ckanext/nhm/lib/helpers.py
+++ b/ckanext/nhm/lib/helpers.py
@@ -780,7 +780,7 @@ def dataset_author_truncate(author_str):
             # Otherwise use the jinja truncate function (may split author name)
             shortened = do_truncate(author_str, length=AUTHOR_MAX_LENGTH, end='')
 
-        return literal('{0} <abbr title="{1}">et al.</abbr>'.format(shortened, author_str))
+        return literal('{0} <abbr title="{1}" style="cursor: pointer;">et al.</abbr>'.format(shortened, author_str))
 
     if len(author_str) > AUTHOR_MAX_LENGTH:
 

--- a/ckanext/nhm/plugin.py
+++ b/ckanext/nhm/plugin.py
@@ -204,8 +204,9 @@ class NHMPlugin(p.SingletonPlugin, p.toolkit.DefaultDatasetForm):
         """
         Shorten author string
         @param pkg_dict:
-        @return: pkg_dict with author field truncated (with HTML!) if necessary
+        @return: pkg_dict with full list of authors renamed to all_authors, and author field truncated (with HTML!) if necessary
         """
+        pkg_dict['all_authors'] = pkg_dict['author']
         pkg_dict['author'] = helpers.dataset_author_truncate(pkg_dict['author'])
         return pkg_dict
 

--- a/ckanext/nhm/theme/fanstatic/resource.config
+++ b/ckanext/nhm/theme/fanstatic/resource.config
@@ -52,3 +52,6 @@ social =
 mam =
     scripts/mam.js
     scripts/vendor/mustache/0.5.0-dev/mustache.js
+
+expand-authors =
+    scripts/modules/expand-authors.js

--- a/ckanext/nhm/theme/fanstatic/scripts/modules/expand-authors.js
+++ b/ckanext/nhm/theme/fanstatic/scripts/modules/expand-authors.js
@@ -1,0 +1,22 @@
+ckan.module('expand-authors', function ($, _) {
+    var self, abbrAuthors, allAuthors, isAbbr;
+    return {
+        initialize: function () {
+            /* Initialises the module.
+             */
+            self = this;
+            var abbr = self.el.children('abbr');
+            allAuthors = abbr.attr('title');
+            abbrAuthors = self.el.html();
+            isAbbr = true;
+            self.el.on('click', jQuery.proxy(this._onClick, this));
+        },
+
+        _onClick: function (event) {
+            event.preventDefault();
+            self.el.html(isAbbr ? allAuthors : abbrAuthors);
+            isAbbr = !isAbbr;
+        }
+
+    }
+});

--- a/ckanext/nhm/theme/templates/package/snippets/additional_info.html
+++ b/ckanext/nhm/theme/templates/package/snippets/additional_info.html
@@ -9,9 +9,10 @@
         {% endif %}
 
         {% if pkg_dict.author %}
+          {% resource 'ckanext-nhm/expand-authors' %}
           <tr>
             <th scope="row" class="dataset-label">{{ _("Author(s)") }}</th>
-            <td class="dataset-details" property="dc:creator">{{ pkg_dict.author }}</td>
+            <td class="dataset-details" property="dc:creator" data-module="expand-authors">{{ pkg_dict.author }}</td>
           </tr>
         {% endif %}
 


### PR DESCRIPTION
Added a new field listing all authors (with no HTML) to be used in meta tags (this fixes the 'et al.' appearing in the header).
Added expand-authors javascript module to toggle showing the full list of authors or the abbreviated version in 'Additional Info'.
closes #293 