### PR TITLE
Insert the shortened author into a unicode HTML string

### DIFF
--- a/ckanext/nhm/lib/helpers.py
+++ b/ckanext/nhm/lib/helpers.py
@@ -781,7 +781,7 @@ def dataset_author_truncate(author_str):
             shortened = do_truncate(author_str, length=AUTHOR_MAX_LENGTH, end='')
 
         try:
-            return literal('{0} <abbr title="{1}" style="cursor: pointer;">et al.</abbr>'.format(shortened, author_str))
+            return literal(u'{0} <abbr title="{1}" style="cursor: pointer;">et al.</abbr>'.format(shortened, author_str))
         except UnicodeEncodeError:
             return author_str
 


### PR DESCRIPTION
The author can have unicode in it and therefore when using format to build the HTML, the HTML string itself needs to be a unicode string.

Builds on https://github.com/NaturalHistoryMuseum/ckanext-nhm/pull/366 to close https://github.com/NaturalHistoryMuseum/data-portal/issues/139.