### PR TITLE
Add test for truncating unicode authors

### DIFF
--- a/ckanext/nhm/lib/helpers.py
+++ b/ckanext/nhm/lib/helpers.py
@@ -780,10 +780,7 @@ def dataset_author_truncate(author_str):
             # Otherwise use the jinja truncate function (may split author name)
             shortened = do_truncate(author_str, length=AUTHOR_MAX_LENGTH, end='')
 
-        try:
-            return literal(u'{0} <abbr title="{1}" style="cursor: pointer;">et al.</abbr>'.format(shortened, author_str))
-        except UnicodeEncodeError:
-            return author_str
+        return literal(u'{0} <abbr title="{1}" style="cursor: pointer;">et al.</abbr>'.format(shortened, author_str))
 
     if author_str and len(author_str) > AUTHOR_MAX_LENGTH:
 

--- a/ckanext/nhm/tests/test_helpers.py
+++ b/ckanext/nhm/tests/test_helpers.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+import unittest
+
+from ckanext.nhm.lib.helpers import dataset_author_truncate
+
+
+class AuthorTruncateTest(unittest.TestCase):
+    '''
+    Tests for the dataset_author_truncate helper function.
+    '''
+
+    def test_untruncated_author(self):
+        '''
+        dataset_author_truncate shouldn't truncate when the author is shorter than the max
+        '''
+        author = u'Dr. Someone'
+        self.assertEqual(author, dataset_author_truncate(author))
+
+    def test_untruncated_unicode_author(self):
+        '''
+        dataset_author_truncate shouldn't truncate when the author is longer than the max
+        and contains unicode characters
+        '''
+        author = u'Dr. Someoné'
+        self.assertEqual(author, dataset_author_truncate(author))
+
+    def test_truncated_author(self):
+        '''
+        dataset_author_truncate should truncate when the author is longer than the max
+        '''
+        author = u', '.join([u'Dr. Someone']*10)
+        try:
+            dataset_author_truncate(author)
+        except UnicodeEncodeError:
+            self.fail("Test unexpectantly threw UnicodeEncodeError when it shouldn't have")
+
+    def test_truncated_unicode_author(self):
+        '''
+        dataset_author_truncate should truncate when the author is longer than the max
+        and contains unicode characters
+        '''
+        author = u', '.join([u'Dr. Someoné']*10)
+        try:
+            dataset_author_truncate(author)
+        except UnicodeEncodeError:
+            self.fail("Test unexpectantly threw UnicodeEncodeError when it shouldn't have")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Removes previous temporary fix from https://github.com/NaturalHistoryMuseum/ckanext-nhm/pull/366 and adds a couple of simple tests.