### PR TITLE
added ckanext-twitter to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ celery==3.1.7
 -e git+https://github.com/NaturalHistoryMuseum/ckanext-list.git#egg=ckanext_list
 -e git+https://github.com/NaturalHistoryMuseum/ckanext-solr-heatmap.git#egg=ckanext_solr_heatmap
 -e git+https://github.com/NaturalHistoryMuseum/ckanext-status.git#egg=ckanext_status
+-e git+https://github.com/NaturalHistoryMuseum/ckanext-twitter.git#egg=ckanext_twitter
 pytz==2013.9
 python-memcached==1.53
 lxml==3.4.4


### PR DESCRIPTION
ckanext-twitter plugin can be found [here](https://github.com/NaturalHistoryMuseum/ckanext-twitter)
closes #328 