### PR TITLE
Ensure non-filterable views are rendered

### DIFF
--- a/ckanext/nhm/theme/templates/package/snippets/resource_view.html
+++ b/ckanext/nhm/theme/templates/package/snippets/resource_view.html
@@ -3,9 +3,7 @@
 
     {% if not to_preview and h.resource_view_is_filterable(resource_view) %}
       {% snippet 'package/snippets/resource_view_search.html', resource_view=resource_view, resource=resource, package=package %}
-    {% endif %}
 
-    {% if not to_preview and h.resource_view_is_filterable(resource_view) %}
       {% if h.is_datasolr_resource(resource['id']) %}
         {% set facets = h.get_resource_facets(resource) %}
       {% endif %}

--- a/ckanext/nhm/theme/templates/package/snippets/resource_view.html
+++ b/ckanext/nhm/theme/templates/package/snippets/resource_view.html
@@ -9,6 +9,7 @@
       {% if h.is_datasolr_resource(resource['id']) %}
         {% set facets = h.get_resource_facets(resource) %}
       {% endif %}
+    {% endif %}
 
     <div class="{% if facets %}row ckanext-datapreview-faceted{% endif %}">
 
@@ -20,7 +21,6 @@
       {% else %}
          {% snippet 'package/snippets/resource_view_rendered.html', resource_view=resource_view, resource=resource, package=package %}
       {% endif %}
-    {% endif %}
     </div>
   </div>
 </div>


### PR DESCRIPTION
The if in this file was preventing views that didn't have filters from being viewed, examples: video and web page views.

Closes https://github.com/NaturalHistoryMuseum/data-portal/issues/137 and https://github.com/NaturalHistoryMuseum/data-portal/issues/113