### PR TITLE
exsiccati -> exsiccata and vice country -> vice county

### DIFF
--- a/ckanext/nhm/views/dwc.py
+++ b/ckanext/nhm/views/dwc.py
@@ -37,7 +37,7 @@ class DarwinCoreView(DefaultView):
         'class',
         'locality',
         'country',
-        'viceCountry',
+        'viceCounty',
         'recordedBy',
         'typeStatus',
         'catalogNumber',

--- a/ckanext/nhm/views/specimen.py
+++ b/ckanext/nhm/views/specimen.py
@@ -85,7 +85,7 @@ class SpecimenView(DefaultView):
             ("stateProvince", "State province"),
             ("mine", "Mine"),
             ("miningDistrict", "Mining district"),
-            ("viceCountry", "Vice country"),
+            ("viceCounty", "Vice County"),
             ("country", "Country"),
             ("continent", "Continent"),
             ("island", "Island"),
@@ -195,8 +195,8 @@ class SpecimenView(DefaultView):
             # "Registered weight unit",  # Merged into Registered weight
         ])),
         ("Botany", OrderedDict([
-            ("exsiccati", "Exsiccati"),
-            ("exsiccatiNumber", "Exsiccati number"),
+            ("exsiccata", "Exsiccata"),
+            ("exsiccataNumber", "Exsiccata number"),
             ("plantDescription", "Plant description"),
             ("cultivated", "Cultivated"),
         ])),


### PR DESCRIPTION
**must** be used in conjunction with PR NaturalHistoryMuseum/data-importer#21.

Possible fix for NaturalHistoryMuseum/data-importer#20 as field name is now the same as it is in the schema.

After merging, will need to change each of the json key names in the database:
```sql
update ecatalogue
set properties = properties - 'exsiccati' || jsonb_build_object('exsiccata', properties->'exsiccati')
returning *;
```
Restart solr and execute dataimport from the solr browser ui.
If it worked, they should appear in the 'fields' section of:
`http://{solr machine url}/solr/collection-specimens/admin/luke?wt=json`

closes #310 and #346 