### PR TITLE
Pass the term in the ajax request to the server

### DIFF
--- a/ckanext/nhm/theme/fanstatic/scripts/modules/resource-view-field-filters.js
+++ b/ckanext/nhm/theme/fanstatic/scripts/modules/resource-view-field-filters.js
@@ -111,9 +111,11 @@ this.ckan.module('resource-view-field-filters', function ($, _) {
                         sort: filterName
                     };
 
-                    // Filter the lookup based on already applied filters
-                    if (searchParams['q']) {
-                        query.q = searchParams['q'];
+                    // filter based on the entered term
+                    if (term) {
+                        var q = {};
+                        q[filterName] = term + ":*";
+                        query.q = JSON.stringify(q);
                     }
                     if(searchParams['filters']){
                         query.filters = JSON.stringify(searchParams['filters']);


### PR DESCRIPTION
We weren't passing the term in the ajax request to the server and thus the results weren't being filtered (in select2 you have to do server side filtering if you're using the ajax method).

Needs https://github.com/NaturalHistoryMuseum/ckanext-datasolr/pull/13 to work properly for Solr resources.

Closes https://github.com/NaturalHistoryMuseum/data-portal/issues/118