### PR TITLE
Never revoke datastore read permissions

### DIFF
--- a/ckanext/nhm/patches/datastore_private_dataset.patch
+++ b/ckanext/nhm/patches/datastore_private_dataset.patch
@@ -1,0 +1,29 @@
+diff --git a/ckanext/datastore/db.py b/ckanext/datastore/db.py
+index 44db853..a7d3430 100644
+--- a/ckanext/datastore/db.py
++++ b/ckanext/datastore/db.py
+@@ -1254,9 +1254,8 @@ def _change_privilege(context, data_dict, what):
+     ''' We need a transaction for this code to work '''
+     read_only_user = _get_read_only_user(data_dict)
+     if what == 'REVOKE':
+-        sql = u'REVOKE SELECT ON TABLE "{0}" FROM "{1}"'.format(
+-            data_dict['resource_id'],
+-            read_only_user)
++        # don't run the revokes to avoid making private datasets unsable
++        return
+     elif what == 'GRANT':
+         sql = u'GRANT SELECT ON TABLE "{0}" TO "{1}"'.format(
+             data_dict['resource_id'],
+diff --git a/ckanext/datastore/logic/auth.py b/ckanext/datastore/logic/auth.py
+index 73d78e0..b7e5c12 100644
+--- a/ckanext/datastore/logic/auth.py
++++ b/ckanext/datastore/logic/auth.py
+@@ -45,7 +45,7 @@ def datastore_search(context, data_dict):
+ 
+ @p.toolkit.auth_allow_anonymous_access
+ def datastore_search_sql(context, data_dict):
+-    return {'success': True}
++    return {'success': False}
+ 
+ 
+ def datastore_change_permissions(context, data_dict):

--- a/ckanext/nhm/theme/templates/ajax_snippets/api_info.html
+++ b/ckanext/nhm/theme/templates/ajax_snippets/api_info.html
@@ -31,10 +31,6 @@
                 <th scope="row">{{ _('Query') }}</th>
                 <td><code>{{ datastore_root_url }}/datastore_search</code></td>
               </tr>
-              <tr>
-                <th scope="row">{{ _('Query (via SQL)') }}</th>
-                <td><code>{{ datastore_root_url }}/datastore_search_sql</code></td>
-              </tr>
 
             </tbody>
           </table>
@@ -57,12 +53,6 @@
           <p>
           <code><a href="{{ datastore_root_url }}/datastore_search?resource_id={{resource_id}}&q=jones"
               target="_blank">{{ datastore_root_url }}/datastore_search?resource_id={{resource_id}}&q=jones</a></code>
-          </p>
-
-          <strong>{{ _('Query example (via SQL statement)') }}</strong>
-          <p>
-          <code><a href="{{sql_example_url}}"
-              target="_blank">{{sql_example_url}}</a></code>
           </p>
 
         </div>


### PR DESCRIPTION
When a private dataset resource table is created in the datastore the access of the read only datastore user is revoked. From what I can tell the only reason for this is to stop API users from accessing the data through the datastore sql search action as this is unauthenticated. This PR removes the revoke and therefore undoes this protection to allow other areas of the ckan code to work with private datasets. Because of this the datastore's SQL search API is also disabled to protect the private datasets.

The actual change to the ckan code is made on this branch [here](https://github.com/NaturalHistoryMuseum/ckan/tree/alter-private-dataset-permissions).