### PR TITLE
Delimit numbers

### DIFF
--- a/ckanext/nhm/patches/delimit_record_count_in_recline.patch
+++ b/ckanext/nhm/patches/delimit_record_count_in_recline.patch
@@ -1,0 +1,17 @@
+diff --git a/ckanext/reclineview/theme/public/widget.recordcount.js b/ckanext/reclineview/theme/public/widget.recordcount.js
+index b47caca..cc8e8bf 100644
+--- a/ckanext/reclineview/theme/public/widget.recordcount.js
++++ b/ckanext/reclineview/theme/public/widget.recordcount.js
+@@ -20,7 +20,11 @@ my.RecordCount = Backbone.View.extend({
+ 
+   render: function() {
+     var tmplData = this.model.toTemplateJSON();
+-    tmplData.recordCount = tmplData.recordCount || 'Unknown number of';
++    if (isNaN(tmplData.recordCount)) {
++      tmplData.recordCount = 'Unknown number of';
++    } else {
++      tmplData.recordCount = tmplData.recordCount.toLocaleString();
++    }
+     var templated = Mustache.render(this.template, tmplData);
+     this.$el.html(templated);
+   }

--- a/ckanext/nhm/theme/templates/package/snippets/resource_view_facets.html
+++ b/ckanext/nhm/theme/templates/package/snippets/resource_view_facets.html
@@ -26,7 +26,7 @@
                {% set href = h.remove_url_filter(facet.name, item.name, extras=extras) if facet.active else h.add_url_filter(facet.name, item.name, extras=extras) %}
                 <li class="nav-item{% if facet.active %} active{% endif %}">
                     <a href="{{ href }}" title="{{ item.label }}">
-                        <span>{{ item.label|title }} ({{ item.count }})</span>
+                        <span>{{ item.label|title }} ({{ h.delimit_number(item.count) }})</span>
                     </a>
                 </li>
             {% endfor %}


### PR DESCRIPTION
Requires the [delimit_record_count_in_recline branch](https://github.com/NaturalHistoryMuseum/ckan/tree/delimit_record_count_in_recline) for the recline.js part of this change.

Closes https://github.com/NaturalHistoryMuseum/data-portal/issues/112