### PR TITLE
Check that the collectionCode is set before use

### DIFF
--- a/ckanext/nhm/lib/jinja_extensions.py
+++ b/ckanext/nhm/lib/jinja_extensions.py
@@ -67,14 +67,15 @@ class TaxonomyFormatExtension(Extension):
             '(?i)min': self._min, }
 
         # get collection-specific rules
-        for rgx, p in collections.items():
-            if re.match(rgx, collection_code):
-                collection_formatted_fields, collection_parsed_fields = p
-                self.format_to_fields = self._merge(global_formatted_fields,
-                                                    collection_formatted_fields)
-                self.parsed_fields = global_parsed_fields + \
-                                     collection_parsed_fields
-                break
+        if collection_code:
+            for rgx, p in collections.items():
+                if re.match(rgx, collection_code):
+                    collection_formatted_fields, collection_parsed_fields = p
+                    self.format_to_fields = self._merge(global_formatted_fields,
+                                                        collection_formatted_fields)
+                    self.parsed_fields = global_parsed_fields + \
+                                         collection_parsed_fields
+                    break
 
         self.field_to_formats = {
             f: [k for k, v in self.format_to_fields.items() if f in v] for f in


### PR DESCRIPTION
If we don't have a collectionCode then we error our when attempting to match it. This affects at least index lot records but possibly other types too.