### PR TITLE
Override plugin interface in ckanpackager to add EML

### DIFF
--- a/ckanext/nhm/lib/eml.py
+++ b/ckanext/nhm/lib/eml.py
@@ -1,0 +1,84 @@
+
+
+def generate_eml(package, resource):
+    '''
+    Given a package and a resource, return some EML that can be used in a download of the resource. This XML string
+    still has two placeholders in it: pub_date and date_stamp which are filled in by the ckanpackager.
+
+    :param package: the package dict
+    :param resource: the resource dict
+    :return: the EML as a string
+    '''
+    # use empty strings as defaults just in case some of these fields don't exist. They should, but we don't want to
+    # raise an exception and therefore stop the request from being sent if something is missing
+    formatting_data = {
+        'resource_id': resource['id'],
+        'title': resource.get('name', ''),
+        'abstract': resource.get('description', ''),
+        'license': package.get('license_title', 'License not specified'),
+        'package_name': package.get('name', ''),
+        'additional_metadata': ''
+    }
+
+    # only include DOI data if we have some to provide
+    if 'doi' in package:
+        formatting_data['additional_metadata'] = '''
+    <additionalMetadata>
+      <metadata>
+        <gbif>
+          <dateStamp>{{date_stamp}}</dateStamp>
+          <citation identifier="https://doi.org/{doi}">{citation}</citation>
+          <resourceLogoUrl>http://data.nhm.ac.uk/images/logo.png</resourceLogoUrl>
+        </gbif>
+      </metadata>
+    </additionalMetadata>
+        '''.format(**{
+            'doi': package['doi'],
+            'citation': 'Natural History Museum http://data.nhm.ac.uk ({0}): {1}'.format(
+                package.get('doi_date_published', '')[:4], package.get('title', '')),
+        }).strip()
+
+    # build the xml string and return it
+    return '''
+<?xml version="1.0" encoding="UTF-8"?>
+<eml:eml xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    packageId="{resource_id}" scope="system" system="http://gbif.org" xml:lang="en"
+                    xsi:schemaLocation="eml://ecoinformatics.org/eml-2.1.1 http://rs.gbif.org/schema/eml-gbif-profile/1.0.2/eml.xsd">
+  <dataset>
+    <title>{title}</title>
+    <creator>
+      <organizationName>The Natural History Museum, London</organizationName>
+      <electronicMailAddress>data@nhm.ac.uk</electronicMailAddress>
+      <onlineUrl>http://data.nhm.ac.uk</onlineUrl>
+    </creator>
+    <metadataProvider>
+      <organizationName>The Natural History Museum, London</organizationName>
+      <electronicMailAddress>data@nhm.ac.uk</electronicMailAddress>
+      <onlineUrl>http://data.nhm.ac.uk</onlineUrl>
+    </metadataProvider>
+    <pubDate>{{pub_date}}</pubDate>
+    <language>en</language>
+    <abstract>
+      <para>{abstract}</para>
+    </abstract>
+    <keywordSet>
+      <keyword>Occurrence</keyword>
+      <keywordThesaurus>GBIF Dataset Type Vocabulary: http://rs.gbif.org/vocabulary/gbif/dataset_type.xml</keywordThesaurus>
+    </keywordSet>
+    <intellectualRights>
+      <para>{license}</para>
+    </intellectualRights>
+    <distribution scope="document">
+      <online>
+        <url function="information">http://data.nhm.ac.uk/dataset/{package_name}</url>
+      </online>
+    </distribution>
+    <contact>
+      <organizationName>The Natural History Museum, London</organizationName>
+      <electronicMailAddress>data@nhm.ac.uk</electronicMailAddress>
+      <onlineUrl>http://data.nhm.ac.uk</onlineUrl>
+    </contact>
+  </dataset>
+  {additional_metadata}
+</eml:eml>
+'''.format(**formatting_data).strip()

--- a/ckanext/nhm/plugin.py
+++ b/ckanext/nhm/plugin.py
@@ -510,8 +510,7 @@ class NHMPlugin(p.SingletonPlugin, p.toolkit.DefaultDatasetForm):
         '''
         resource = get_action('resource_show')(None, {'id': resource_id})
         package = get_action('package_show')(None, {'id': package_id})
-        if resource.get('datastore_active', False):
-            if resource.get('format', '').lower() == 'dwc':
-                # if it's a datastore resource and it's in the DwC format, add EML
-                request_params['eml'] = generate_eml(package, resource)
+        if resource.get('datastore_active', False) and resource.get('format', '').lower() == 'dwc':
+            # if it's a datastore resource and it's in the DwC format, add EML
+            request_params['eml'] = generate_eml(package, resource)
         return packager_url, request_params

--- a/ckanext/nhm/plugin.py
+++ b/ckanext/nhm/plugin.py
@@ -21,6 +21,7 @@ import ckanext.nhm.lib.helpers as helpers
 import logging
 from jinja2 import Environment
 
+from ckanext.nhm.lib.eml import generate_eml
 from ckanext.nhm.lib.helpers import (
     resource_view_get_filter_options,
     # NOTE: Need to import a function with a cached decorator so clear caches works
@@ -34,6 +35,7 @@ from collections import OrderedDict
 from ckanext.doi.interfaces import IDoi
 from ckanext.datasolr.interfaces import IDataSolr
 from ckanext.gallery.plugins.interfaces import IGalleryImage
+from ckanext.ckanpackager.interfaces import ICkanPackager
 from ckanext.nhm.lib.cache import cache_clear_nginx_proxy
 
 get_action = logic.get_action
@@ -65,6 +67,7 @@ class NHMPlugin(p.SingletonPlugin, p.toolkit.DefaultDatasetForm):
     p.implements(IContact)
     p.implements(IDoi)
     p.implements(IGalleryImage)
+    p.implements(ICkanPackager)
 
     ## IConfigurer
     def update_config(self, config):
@@ -492,3 +495,23 @@ class NHMPlugin(p.SingletonPlugin, p.toolkit.DefaultDatasetForm):
                     'record_id': record['_id']
                 })
         return images
+
+    ## ICkanPackager
+    def before_package_request(self, resource_id, package_id, packager_url, request_params):
+        '''
+        Modify the request params that are about to be sent through to the ckanpackager backend so that an EML param is
+        included.
+
+        :param resource_id: the resource id of the resource that is about to be packaged
+        :param package_id: the package id of the resource that is about to be packaged
+        :param packager_url: the target url for this packaging request
+        :param request_params: a dict of parameters that will be sent with the request
+        :return: the url and the params as a tuple
+        '''
+        resource = get_action('resource_show')(None, {'id': resource_id})
+        package = get_action('package_show')(None, {'id': package_id})
+        if resource.get('datastore_active', False):
+            if resource.get('format', '').lower() == 'dwc':
+                # if it's a datastore resource and it's in the DwC format, add EML
+                request_params['eml'] = generate_eml(package, resource)
+        return packager_url, request_params


### PR DESCRIPTION
Adding the EML to our DwC-A makes them more compatible for services like GGBN.

Closes https://github.com/NaturalHistoryMuseum/data-portal/issues/128.
Requires https://github.com/NaturalHistoryMuseum/ckanext-ckanpackager/pull/8.