### PR TITLE
Add a maxlength to the text box to avoid blockages through the WAF

### DIFF
--- a/ckanext/nhm/theme/templates/contact/snippets/form.html
+++ b/ckanext/nhm/theme/templates/contact/snippets/form.html
@@ -84,7 +84,10 @@
 
     {% endif %}
 
-    {{ form.markdown('content', label=_('Your request'), id='field-content', value=data.content, error=errors.content, is_required=true) }}
+    {# using a max length of of 1500 on the text box as the WAF has a 1500 character limit on #}
+    {# this parameter and will block requests that exceed it #}
+    {{ form.markdown('content', label=_('Your request'), id='field-content', value=data.content,
+                     error=errors.content, is_required=true, attrs={'maxlength': 1500}) }}
 
 {% endblock %}
 


### PR DESCRIPTION
The WAF blocks requests with parameter values over certain lengths. For the content parameter in contact forms the length is 1500 characters and therefore we need this to stop users getting blocked.

Closes https://github.com/NaturalHistoryMuseum/ckanext-nhm/issues/420