### PR TITLE
A selection of minor ckan upgrade related fixes

### DIFF
--- a/ckanext/nhm/lib/helpers.py
+++ b/ckanext/nhm/lib/helpers.py
@@ -79,7 +79,7 @@ def _get_action(action, params):
     '''Call basic get_action from template.
 
     :param action:
-    :param params: 
+    :param params:
 
     '''
     context = {
@@ -352,8 +352,8 @@ def persistent_follow_button(obj_type, obj_id):
     For anon users this function outputs a follow button which links through to the
     login page
 
-    :param obj_type: 
-    :param obj_id: 
+    :param obj_type:
+    :param obj_id:
     :returns:
 
     '''
@@ -467,7 +467,7 @@ def get_resource_fields(resource, version=None, use_request_version=False):
         if u'__version__' in filters:
             data[u'version'] = int(filters[u'__version__'][0])
 
-    result = logic.get_action(u'datastore_search')({}, data)
+    result = toolkit.get_action(u'datastore_search')({}, data)
     return [field[u'id'] for field in result.get(u'fields', [])]
 
 
@@ -476,7 +476,7 @@ def resource_view_state(resource_view_json, resource_json):
     '''Alter the recline view resource, adding in state info
 
     :param resource_view_json: return:
-    :param resource_json: 
+    :param resource_json:
 
     '''
     resource_view = json.loads(resource_view_json)
@@ -547,7 +547,7 @@ def resource_is_dwc(resource):
 def camel_case_to_string(camel_case_string):
     '''
 
-    :param camel_case_string: 
+    :param camel_case_string:
 
     '''
     s = u' '.join(re.findall(r'[A-Z]?[a-z]+|[A-Z]+(?=[A-Z]|$)', camel_case_string))
@@ -558,7 +558,7 @@ def get_resource_filter_options(resource, resource_view):
     '''Return the available filter options for the given resource
 
     :param resource: Dictionary representing a resource
-    :param resource_view: 
+    :param resource_view:
     :returns: A dictionary associating each option's name to a dict defining:
                 - label: The label to display to users;
                 - checked: True if the option is currently applied.
@@ -613,7 +613,7 @@ def get_allowed_view_types(resource, package):
     We want to edit some of the options - remove Image and change Tiled Map to Map
 
     :param resource: param package:
-    :param package: 
+    :param package:
 
     '''
 
@@ -654,8 +654,8 @@ def get_facet_label_function(facet_name, multi=False):
         def filter_facets(facet, filter_value):
             '''
 
-            :param facet: 
-            :param filter_value: 
+            :param facet:
+            :param filter_value:
 
             '''
             for f in facet:
@@ -686,7 +686,7 @@ def get_creator_id_facet_label(facet):
 def field_name_label(field_name):
     '''Convert a field name into a label - replacing _s and upper casing first character
 
-    :param field_name: 
+    :param field_name:
     :returns: str label
 
     '''
@@ -735,7 +735,7 @@ def record_display_field(field_name, value):
     Evaluates whether a field has value
 
     :param field_name:
-    :param value: 
+    :param value:
     :returns: bool - true to display field; false not to
 
     '''
@@ -837,7 +837,7 @@ def dataset_author_truncate(author_str):
     def _truncate(author_str, separator=None):
         '''
 
-        :param author_str: 
+        :param author_str:
         :param separator:  (optional, default: None)
 
         '''

--- a/ckanext/nhm/theme/templates/contact/snippets/modal_link.html
+++ b/ckanext/nhm/theme/templates/contact/snippets/modal_link.html
@@ -2,8 +2,6 @@
 
 {% block modal_link %}
 
-    {% set params = h.get_contact_form_params(pkg=g.pkg, res=res, rec=rec) %}
-
     <a class="btn btn-primary" title="{{ _('Contact') }}" data-module="modal-contact"
        data-module-template="contact_form.html"
        {% if pkg %} data-module-package_id="{{ pkg.id }}" {% endif %}

--- a/ckanext/nhm/theme/templates/package/resource_read.html
+++ b/ckanext/nhm/theme/templates/package/resource_read.html
@@ -5,9 +5,7 @@
     <li>{% link_for _('Data'), named_route='dataset.search' %}</li>
     <li>{% link_for dataset|truncate(30), named_route='dataset.read', id=g.pkg.name %}</li>
     {# Added actual URL as IE9 doesn't like empty hrefs & we want to remove the filters #}
-    <li class="active">
-        <a href="{{ h.url_for('resource.read', id=g.pkg.name, resource_id=res.id) }}">{{ h.resource_display_name(res)|truncate(30) }}</a>
-    </li>
+    <li class="active"><a href="{{ h.url_for('resource.read', id=g.pkg.name, resource_id=res.id) }}">{{ h.resource_display_name(res)|truncate(30) }}</a></li>
 {% endblock %}
 
 {% block resource_inner %}

--- a/ckanext/nhm/theme/templates/record/view.html
+++ b/ckanext/nhm/theme/templates/record/view.html
@@ -81,7 +81,7 @@
 
             {% block record_data %}
 
-            <table>
+            <table class="table-record">
                 {% for field_name, value in g.field_data.items() %} {% if
                 h.record_display_field(field_name, value) %}
 


### PR DESCRIPTION
- fix `HelperError: Helper 'get_contact_form_params' has not been defined.` error
- use `table-record` class on base record page for better visuals
- make sure `get_action` usage is the same across helpers module (i.e. using `toolkit.get_action` instead of `logic.get_action`)
- fix issue with resource breadcrumbs in chrome