### PR TITLE
Include permanentUrl in specimen record responses if necessary

### DIFF
--- a/ckanext/nhm/plugin.py
+++ b/ckanext/nhm/plugin.py
@@ -495,7 +495,13 @@ class NHMPlugin(p.SingletonPlugin, p.toolkit.DefaultDatasetForm):
 
     # IVersionedDatastore
     def datastore_modify_result(self, context, original_data_dict, data_dict, result):
-        # we don't do anything to the result currently
+        # if there's the include_urls parameter then include the permanent url of each specimen
+        if helpers.get_specimen_resource_id() == data_dict[u'resource_id'] and \
+                u'include_urls' in original_data_dict:
+            for hit in result.hits:
+                if u'occurrenceID' in hit.data:
+                    hit.data.permanentUrl = url_for(u'object_view', uuid=hit.data.occurrenceID)
+
         return result
 
     # IVersionedDatastore


### PR DESCRIPTION
Requested by @llivermore but also a part of https://github.com/NaturalHistoryMuseum/data-portal/issues/366.

Simply include a `include_urls` parameter in `datastore_search` requests. The value of the parameter doesn't matter, just it's presence is required. For example:

https://data.nhm.ac.uk/api/3/action/datastore_search?resource_id=05ff2255-c38a-40c9-b657-4ccb55ab2feb&include_urls=true

Returns:

```json
...
      {
        "family": "Coenagriidae",
        "institutionCode": "NHMUK",
        "phylum": "Arthropoda",
        "preservative": "Dry - mounted",
        "occurrenceID": "b5513cd1-9dc4-46f7-8e3a-7578352bc161",
        "higherClassification": "Arthropoda; Insecta; Odonata; Coenagriidae; Teinobasinae",
        "basisOfRecord": "Specimen",
        "otherCatalogNumbers": "NHMUK:ecatalogue:8979896",
        "catalogNumber": "NHMUK013383630",
        "specificEpithet": "bradleyi",
        "barcode": "013383630",
        "collectionCode": "BMNH(E)",
        "determinationNames": "Teinobasis bradleyi Kimmins",
        "typeStatus": "LECTOTYPE",
        "class": "Insecta",
        "individualCount": "1",
        "_id": 8979896,
        "created": 1565773013000,
        "permanentUrl": "/object/b5513cd1-9dc4-46f7-8e3a-7578352bc161",
        "modified": 1565843907000,
        "scientificName": "Teinobasis bradleyi Kimmins",
        "scientificNameAuthorship": "Kimmins",
        "genus": "Teinobasis",
        "order": "Odonata"
      }
...
```