### PR TITLE
Make a specific endpoint which provides the CETAF stable identifier for specimen records

### DIFF
--- a/ckanext/nhm/logic/action.py
+++ b/ckanext/nhm/logic/action.py
@@ -202,16 +202,16 @@ def get_permanent_url(context, data_dict):
             u'total': total,
         })
     else:
+        uuid = records[0][u'occurrenceID']
         if include_version:
             # figure out the latest rounded version of the specimen resource data
             version = get_action(u'datastore_get_rounded_version')(context, {
                 u'resource_id': helpers.get_specimen_resource_id()
             })
-            # create a permanent url with the version included
-            return u'{}{}'.format(config.get(u'ckan.site_url'),
-                                  url_for(u'object_view_versioned',
-                                          uuid=records[0][u'occurrenceID'],
-                                          version=version))
+            # create a path with the version included
+            path = url_for(u'object_view_versioned', uuid=uuid, version=version)
         else:
-            return u'{}{}'.format(config.get(u'ckan.site_url'),
-                                  url_for(u'object_view', uuid=records[0][u'occurrenceID']))
+            path = url_for(u'object_view', uuid=uuid)
+
+        # concatenate the path with the site url and return
+        return u'{}{}'.format(config.get(u'ckan.site_url'), path)

--- a/ckanext/nhm/logic/action.py
+++ b/ckanext/nhm/logic/action.py
@@ -5,9 +5,12 @@ import ckanext.nhm.logic.schema as nhm_schema
 import ckan.logic as logic
 import ckan.model as model
 from ckan.common import c
+from ckan.lib.helpers import url_for
+from ckanext.nhm.lib import helpers
 from ckanext.nhm.lib.mam import mam_media_request
 from ckanext.nhm.dcat.specimen_records import ObjectSerializer
 from ckanext.nhm.lib.record import get_record_by_uuid
+from pylons import config
 
 NotFound = logic.NotFound
 ActionError = logic.ActionError
@@ -144,3 +147,56 @@ def _image_exists_on_record(resource, record, asset_id):
         if asset_id in url:
             return True
     return False
+
+
+@logic.side_effect_free
+def get_permanent_url(context, data_dict):
+    '''
+    Retrieve the permanent URL of a specimen from the specimen collection using the field and value
+    to filter the results (i.e. field must equal value for the record to match). A URL is returned
+    only if exactly one record is matched by the field and value combination. If more than 1 record
+    is matched or if 0 records are matched then an error is returned.
+
+    **Params:**
+
+    :param field: the name of the field you would like to filter the records on
+    :type field: string
+    :param value: the value of the field to filter by
+    :type value: string
+
+    **Results:**
+
+    :returns: the full URL of the specimen
+    :rtype: string
+    '''
+    schema = context.get(u'schema', nhm_schema.get_permanent_url_schema())
+    data_dict, errors = _validate(data_dict, schema, context)
+
+    # extract the request parameters
+    field = data_dict[u'field']
+    value = data_dict[u'value']
+
+    # create a search dict to use with the datastore_search action
+    search_dict = {
+        u'resource_id': helpers.get_specimen_resource_id(),
+        u'filters': {
+            field: value
+        },
+        u'limit': 1,
+    }
+    result = get_action(u'datastore_search')(context, search_dict)
+    records = result[u'records']
+    total = result[u'total']
+    if total == 0:
+        raise logic.ValidationError({
+            u'message': u'No records found matching the given criteria',
+            u'total': total,
+        })
+    elif total > 1:
+        raise logic.ValidationError({
+            u'message': u'More than 1 record found matching the given criteria',
+            u'total': total,
+        })
+    else:
+        return u'{}{}'.format(config.get(u'ckan.site_url'),
+                              url_for(u'object_view', uuid=records[0][u'occurrenceID']))

--- a/ckanext/nhm/logic/schema.py
+++ b/ckanext/nhm/logic/schema.py
@@ -113,4 +113,5 @@ def get_permanent_url_schema():
     return {
         u'field': [not_missing, unicode],
         u'value': [not_missing, unicode],
+        u'include_version': [ignore_missing, boolean_validator],
     }

--- a/ckanext/nhm/logic/schema.py
+++ b/ckanext/nhm/logic/schema.py
@@ -107,3 +107,10 @@ def show_package_schema():
     # This is the same as the extras field with key=spatial for ckanext-spatial
     schema['spatial'] = [convert_from_extras, ignore_missing]
     return schema
+
+
+def get_permanent_url_schema():
+    return {
+        u'field': [not_missing, unicode],
+        u'value': [not_missing, unicode],
+    }

--- a/ckanext/nhm/plugin.py
+++ b/ckanext/nhm/plugin.py
@@ -158,7 +158,8 @@ class NHMPlugin(p.SingletonPlugin, p.toolkit.DefaultDatasetForm):
         return {
             'record_show': nhm_action.record_show,
             'object_rdf': nhm_action.object_rdf,
-            'download_image': nhm_action.download_original_image
+            'download_image': nhm_action.download_original_image,
+            u'get_permanent_url': nhm_action.get_permanent_url,
         }
 
     # ITemplateHelpers


### PR DESCRIPTION
Further implementation for @llivermore. 

There are 3 parameters:

- `field` - the name of the field you would like to filter the records on (for example `barcode` or `_id`)
- `value` - the value of the field to filter by (for example `013383692` or `4977891`)
- `include_version` - whether to include the version in the permanent URL (default is `false`, if provided should be a boolean compatible value like `true` or `false`)

A URL is returned if exactly 1 record is matched for the field, value combination. If 0 records are matched or more than 1 records are matched an error is returned. 

Usage examples:

### A single record matched using `barcode` = `013383692`
`GET` https://data.nhm.ac.uk/api/3/action/get_permanent_url?field=barcode&value=013383692

Status code: `200`

JSON response:
```json
{
  "help": "...",
  "success": true,
  "result": "https://data.nhm.ac.uk/object/fd9d992b-7424-4103-acb8-1626a6c66aeb"
}
```

### A single record matched using `barcode` = `013383692` with the version
`GET` https://data.nhm.ac.uk/api/3/action/get_permanent_url?field=barcode&value=013383692&include_version=true

Status code: `200`

JSON response:
```json
{
  "help": "...",
  "success": true,
  "result": "https://data.nhm.ac.uk/object/fd9d992b-7424-4103-acb8-1626a6c66aeb/1565827200000"
}
```

### 0 records matched using `barcode` = `blah`
`GET` https://data.nhm.ac.uk/api/3/action/get_permanent_url?field=barcode&value=blah

Status code: `409`

JSON response:

```json
{
  "help": "...",
  "success": false,
  "error": {
    "message": "No records found matching the given criteria",
    "total": 0,
    "__type": "Validation Error"
  }
}
```

### More than 1 records matched using `family` = `scarabaeidae`
`GET` https://data.nhm.ac.uk/api/3/action/get_permanent_url?field=family&value=scarabaeidae

Status code: `409`

JSON response:
```json
{
  "help": "...",
  "success": false,
  "error": {
    "message": "More than 1 record found matching the given criteria",
    "total": 40254,
    "__type": "Validation Error"
  }
}
```
