### PR TITLE
q is now unicode so we don't need to decode it to get a unicode value

### DIFF
--- a/ckanext/nhm/theme/templates/package/snippets/resource_view_search.html
+++ b/ckanext/nhm/theme/templates/package/snippets/resource_view_search.html
@@ -13,7 +13,7 @@
 
             <div class="col-md-9 col-sm-9">
                 <div class="search-input control-group">
-                  <input type="text" class="search" name="q" autocomplete="off" value="{{ q.decode('utf-8') }}" placeholder="{% block search_placeholder %}{{ placeholder }}{% endblock %}" />
+                  <input type="text" class="search" name="q" autocomplete="off" value="{{ q }}" placeholder="{% block search_placeholder %}{{ placeholder }}{% endblock %}" />
                   <input type="hidden" name="view_id" value="{{ resource_view['id'] }}" />
                   {% if query_params['filters'] %}
                       <input type="hidden" name="filters" value="{{ query_params['filters'] }}" />


### PR DESCRIPTION
This should fix the searching with a unicode value problem: i.e. https://data.nhm.ac.uk/dataset/56e711e6-c847-4f99-915a-6894bb5c5dea/resource/05ff2255-c38a-40c9-b657-4ccb55ab2feb?q=%C3%A9