### PR TITLE
Add back in the contributors stats page

### DIFF
--- a/ckanext/nhm/routes/statistics.py
+++ b/ckanext/nhm/routes/statistics.py
@@ -117,40 +117,7 @@ def contributors():
     '''
     Render the contributors statistics page.
     '''
-    # we use solr to get the number of authors for the front page statistics so we'll use it again
-    # here to get a per-package authors count. We have to use solr directly to do this because the
-    # package_search action doesn't allow the pivot options to be passed through
-    solr = make_connection()
-    results = solr.search(u'*:*', **{
-        u'facet': u'true',
-        u'facet.pivot': u'id,author',
-        u'facet.pivot.mincount': 1,
-        u'facet.limit': -1,
-    }).facets.get(u'facet_pivot', {}).get(u'id,author', [])
-
-    # turn the counts into a lookup from package_id -> number of authors
-    counts = {hit[u'value']: len(hit[u'pivot']) for hit in results}
-    # retrieve the packages in the database ordered by creation time. We need this because we can't
-    # order the solr facets by created date
-    order = list(model.Session.query(model.Package.id, model.Package.metadata_created)
-                 .order_by(model.Package.metadata_created))
-
-    # get the earliest package creation date
-    delta = datetime.now() - order[0][1]
-    # if we have data for more than 10 days, we'll show by month; otherwise segment by day
-    extraction_format = u'%b %Y' if delta.days > 10 else u'%d/%m/%y'
-
-    # sum the counts by package creation time based on the extraction format we chose
-    grouped_ordered_data = OrderedDict()
-    for package_id, created in order:
-        # just in case the database isn't up to date with the solr index
-        if package_id not in counts:
-            continue
-        date_group = created.strftime(extraction_format)
-        if date_group not in grouped_ordered_data:
-            grouped_ordered_data[date_group] = 0
-        grouped_ordered_data[date_group] += counts[package_id]
-
+    # default the graph options
     toolkit.c.graph_options = {
         u'series': {
             u'lines': {
@@ -169,13 +136,49 @@ def contributors():
         }
     }
     toolkit.c.graph_data = []
-    total = 0
 
-    # run through the data, adding up a total as we go and adding the data to the graph
-    for i, (formatted_date, count) in enumerate(grouped_ordered_data.items()):
-        total += count
-        toolkit.c.graph_data.append([i, total])
-        toolkit.c.graph_options[u'xaxis'][u'ticks'].append([i, formatted_date])
+    # we use solr to get the number of authors for the front page statistics so we'll use it again
+    # here to get a per-package authors count. We have to use solr directly to do this because the
+    # package_search action doesn't allow the pivot options to be passed through
+    solr = make_connection()
+    results = solr.search(u'*:*', **{
+        u'facet': u'true',
+        u'facet.pivot': u'id,author',
+        u'facet.pivot.mincount': 1,
+        u'facet.limit': -1,
+    }).facets.get(u'facet_pivot', {}).get(u'id,author', [])
+
+    # turn the counts into a lookup from package_id -> number of authors
+    counts = {hit[u'value']: len(hit[u'pivot']) for hit in results}
+    # retrieve the packages in the database ordered by creation time. We need this because we can't
+    # order the solr facets by created date
+    order = list(model.Session.query(model.Package.id, model.Package.metadata_created)
+                 .order_by(model.Package.metadata_created))
+
+    # only do stuff if we have some packages
+    if order:
+        # get the earliest package creation date
+        delta = datetime.now() - order[0][1]
+        # if we have data for more than 10 days, we'll show by month; otherwise segment by day
+        extraction_format = u'%b %Y' if delta.days > 10 else u'%d/%m/%y'
+
+        # sum the counts by package creation time based on the extraction format we chose
+        grouped_ordered_data = OrderedDict()
+        for package_id, created in order:
+            # just in case the database isn't up to date with the solr index
+            if package_id not in counts:
+                continue
+            date_group = created.strftime(extraction_format)
+            if date_group not in grouped_ordered_data:
+                grouped_ordered_data[date_group] = 0
+            grouped_ordered_data[date_group] += counts[package_id]
+
+        total = 0
+        # run through the data, adding up a total as we go and adding the data to the graph
+        for i, (formatted_date, count) in enumerate(grouped_ordered_data.items()):
+            total += count
+            toolkit.c.graph_data.append([i, total])
+            toolkit.c.graph_options[u'xaxis'][u'ticks'].append([i, formatted_date])
 
     return toolkit.render(u'stats/resources.html', {
         u'title': u'Contributor statistics'

--- a/ckanext/nhm/theme/templates/stats/base.html
+++ b/ckanext/nhm/theme/templates/stats/base.html
@@ -9,6 +9,7 @@
 {% block content_primary_nav %}
   {{ h.build_nav_icon('statistics.resources', _('Resources'), icon='bar-chart-o') }}
   {{ h.build_nav_icon('statistics.records', _('Records'), icon='file-text') }}
+  {{ h.build_nav_icon('statistics.contributors', _('Contributors'), icon='user-friends') }}
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckanext/nhm/theme/templates/stats/contributors.html
+++ b/ckanext/nhm/theme/templates/stats/contributors.html
@@ -1,0 +1,22 @@
+{% extends "stats/base.html" %}
+
+{% block breadcrumb_content %}
+    {{ super() }}
+    <li class="active">{% link_for _(title), named_route='statistics.contributors' %}</li>
+{% endblock %}
+
+
+{% block stats_content %}
+
+    <section id="stats-total-contributors">
+
+      <h4>{{ _('Total number of contributors') }}</h4>
+      <div data-module="graph" data-module-data="{{ h.dump_json(g.graph_data) }}"
+           data-module-config="{{ h.dump_json(g.graph_options) }}"
+           style="width:100%; height:300px;">
+      </div>
+      {% resource 'ckanext-graph/main' %}
+
+    </section>
+
+{% endblock %}


### PR DESCRIPTION
This was removed during the ckan upgrade after we removed the author count from the front page. We added the author count back in later but forgot to resurrect the authors stats page. This resurrects it using the new, higher, solr based author count.