### PR TITLE
Fix up a couple of SEO issues

### DIFF
--- a/ckanext/nhm/lib/helpers.py
+++ b/ckanext/nhm/lib/helpers.py
@@ -1380,3 +1380,23 @@ def build_nav_main(*args):
     '''
     from_core = core_helpers.build_nav_main(*args)
     return _add_nav_item_class(from_core)
+
+
+def get_specimen_jsonld(uuid, version=None):
+    '''
+    Returns the rdf representation of the given specimen uuid. The returned data is a string of
+    json-ld data. If something goes wrong, an empty string is returned.
+
+    :param uuid: the uuid of the specimen record
+    :param version: optional version for the record data
+    :return: string of dumped json-ld data
+    '''
+    data_dict = {
+        u'uuid': uuid,
+        u'format': u'json-ld',
+        u'version': version,
+    }
+    try:
+        return toolkit.get_action(u'object_rdf')({}, data_dict)
+    except toolkit.ValidationError, e:
+        return u''

--- a/ckanext/nhm/lib/helpers.py
+++ b/ckanext/nhm/lib/helpers.py
@@ -8,14 +8,14 @@ import itertools
 import json
 import logging
 import operator
-import time
-import urllib
-from collections import OrderedDict, defaultdict
-from operator import itemgetter
-
 import os
 import re
+import time
+import urllib
 from beaker.cache import cache_region
+from ckan import model
+from ckan.lib import helpers as core_helpers
+from ckan.plugins import toolkit
 from ckanext.gbif.lib.errors import GBIF_ERRORS
 from ckanext.nhm.lib import external_links
 from ckanext.nhm.lib.form import list_to_form_options
@@ -24,14 +24,12 @@ from ckanext.nhm.lib.resource_view import (resource_view_get_filter_options,
 from ckanext.nhm.lib.taxonomy import extract_ranks
 from ckanext.nhm.logic.schema import DATASET_TYPE_VOCABULARY, UPDATE_FREQUENCIES
 from ckanext.nhm.settings import COLLECTION_CONTACTS
+from collections import OrderedDict, defaultdict
 from datetime import datetime
 from jinja2.filters import do_truncate
 from lxml import etree, html
+from operator import itemgetter
 from webhelpers.html import literal
-
-from ckan import model
-from ckan.lib import helpers as core_helpers
-from ckan.plugins import toolkit
 
 log = logging.getLogger(__name__)
 

--- a/ckanext/nhm/tests/test_helpers.py
+++ b/ckanext/nhm/tests/test_helpers.py
@@ -103,7 +103,8 @@ class TestGetSpecimenJSONLD(TestBase):
         with patch(u'ckanext.nhm.lib.helpers.toolkit', mock_toolkit):
             uuid = u'beans'
             get_specimen_jsonld(uuid)
-            mock_get_action.assert_called_once_with({}, {
+            mock_get_action.assert_called_once_with(u'object_rdf')
+            mock_get_action(u'object_rdf').assert_called_once_with({}, {
                 u'uuid': uuid,
                 u'format': u'json-ld',
                 u'version': None
@@ -116,7 +117,8 @@ class TestGetSpecimenJSONLD(TestBase):
             uuid = u'beans'
             version = 327947382
             get_specimen_jsonld(uuid, version)
-            mock_get_action.assert_called_once_with({}, {
+            mock_get_action.assert_called_once_with(u'object_rdf')
+            mock_get_action(u'object_rdf').assert_called_once_with({}, {
                 u'uuid': uuid,
                 u'format': u'json-ld',
                 u'version': 327947382

--- a/ckanext/nhm/tests/test_helpers.py
+++ b/ckanext/nhm/tests/test_helpers.py
@@ -95,7 +95,7 @@ class TestGetSpecimenJSONLD(TestBase):
         mock_get_action = MagicMock(side_effect=toolkit.ValidationError(u'test'))
         mock_toolkit = MagicMock(get_action=mock_get_action)
         with patch(u'ckanext.nhm.lib.helpers.toolkit', mock_toolkit):
-            nose.tools.assert_raises(toolkit.ValidationException, get_specimen_jsonld, MagicMock())
+            nose.tools.assert_raises(toolkit.ValidationError, get_specimen_jsonld, MagicMock())
 
     def test_normal(self):
         mock_get_action = MagicMock()

--- a/ckanext/nhm/theme/templates/record/specimen.html
+++ b/ckanext/nhm/theme/templates/record/specimen.html
@@ -1,5 +1,18 @@
 {% extends "record/collection.html" %}
 
+{% block head_extras -%}
+    {{ super() }}
+    {% set canonical_url = h.get_object_url(res.id, g.record_dict['occurrenceID'], include_version=False) %}
+    <meta property="og:url" content="{{ canonical_url }}">
+    <link rel="canonical" href="{{ canonical_url }}" />
+
+    <!-- this isn't right as we're not matching up to a schema.org @context but until we
+         decide how to deal with this, here's the rdf version of this specimen in jsonld -->
+    <script type="application/ld+json">
+        {{ h.get_specimen_jsonld(g.record_dict['occurrenceID']) | indent(8) | safe }}
+    </script>
+{% endblock -%}
+
 {% block styles %}
    {{ super() }}
    <link rel="alternate" type="text/n3" href="{{ h.url_for('object.rdf', uuid=g.record_dict['occurrenceID'], _format='n3', qualified=True) }}"/>

--- a/ckanext/nhm/theme/templates/record/view.html
+++ b/ckanext/nhm/theme/templates/record/view.html
@@ -2,9 +2,10 @@
 
 {% set rec = g.record_dict %}{% set res = g.resource %}{% set filterable_fields = h.resource_view_get_filterable_fields(res) %}
 
-{% block head_extras -%}{{ super() }}
-<meta property="og:title"
-      content="{{ h.dataset_display_name(g.package) }} - {{ h.resource_display_name(res) }} - {{ g.record_title }} - {{ g.site_title }}">{% endblock -%}
+{% block head_extras -%}
+    {{ super() }}
+    <meta property="og:title" content="{{ h.dataset_display_name(g.package) }} - {{ h.resource_display_name(res) }} - {{ g.record_title }} - {{ g.site_title }}">
+{% endblock -%}
 
 {% block subtitle %}{{ h.dataset_display_name(g.package) }} - {{ h.resource_display_name(res) }} - {{ g.record_title }} {% endblock %}
 


### PR DESCRIPTION
Add og:url and canonical urls to specimen pages.
Add jsonld to specimen pages, though not quite in line with [the recommendations](https://developers.google.com/search/docs/guides/intro-structured-data?hl=en#structured-data) as I wasn't sure how to map to the [schema.org](https://schema.org/docs/full.html) context options. That requires a bit more thought me thinks! 