### PR TITLE
Send HTML download emails

### DIFF
--- a/ckanext/nhm/src/download_emails/body.html
+++ b/ckanext/nhm/src/download_emails/body.html
@@ -1,0 +1,24 @@
+<html lang="en">
+<body>
+<p>Hello,</p>
+
+<p>
+    The link to the resource data you requested on <a href="{{ site_url }}">{{ site_url }}</a> is
+    available at <a href="{{ download_url }}">{{ download_url }}</a>.
+</p>
+
+{# we should only not have a DOI if an error has occurred #}
+{% if doi is defined %}
+<p>
+    A DOI has been created for this data:
+    <a href="https://doi.org/{{ doi }}">https://doi.org/{{ doi }}</a> (this may take a few hours to
+    become active). Please ensure you reference this DOI when citing this data.
+    <br/>
+    For more information, follow the DOI link.
+</p>
+{% endif %}
+
+<p>Best Wishes,</p>
+<p>The NHM Data Portal Bot</p>
+</body>
+</html>

--- a/ckanext/nhm/src/download_emails/body.txt
+++ b/ckanext/nhm/src/download_emails/body.txt
@@ -1,0 +1,12 @@
+Hello,
+
+The link to the resource data you requested on {{ site_url }} is available at {{ download_url }}.
+
+{% if doi is defined %}
+A DOI has been created for this data: https://doi.org/{{ doi }} (this may take a few hours to become active). Please ensure you reference this DOI when citing this data.
+
+For more information, follow the DOI link.
+{% endif %}
+
+Best Wishes,
+The NHM Data Portal Bot

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,9 @@ ckan_extensions = OrderedDict([
     github('ckanext-gbif', 'v2.0.0'),
     github('ckanext-graph', 'v2.0.0'),
     github('ckanext-ldap', 'v3.0.0'),
-    github('ckanext-query-dois', 'v2.0.1'),
+    github('ckanext-query-dois', 'v2.0.2'),
     github('ckanext-statistics', 'v2.0.0'),
-    github('ckanext-versioned-datastore', 'v2.0.0'),
+    github('ckanext-versioned-datastore', 'v3.0.0'),
 ])
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ ckan_extensions = OrderedDict([
     github('ckanext-graph', 'v2.0.0'),
     github('ckanext-ldap', 'v3.0.0'),
     github('ckanext-query-dois', 'v2.0.2'),
-    github('ckanext-statistics', 'v2.0.0'),
+    github('ckanext-statistics', 'v2.0.1'),
     github('ckanext-versioned-datastore', 'v3.0.0'),
 ])
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from ckanext.nhm.plugin import NHMPlugin
+
+
+def test_download_modify_email_templates():
+    plugin = NHMPlugin()
+
+    original_plain = 'original plain'
+    original_html = 'original html'
+
+    base = Path(__file__).parent.parent / 'ckanext' / 'nhm' / 'src' / 'download_emails'
+    with (base / 'body.txt').open() as f:
+        plain_contents = f.read().strip()
+    with (base / 'body.html').open() as f:
+        html_contents = f.read().strip()
+
+    plain, html = plugin.download_modify_email_templates(original_plain, original_html)
+
+    assert plain != original_plain
+    assert html != original_html
+    assert plain == plain_contents
+    assert html == html_contents


### PR DESCRIPTION
This requires https://github.com/NaturalHistoryMuseum/ckanext-versioned-datastore/pull/42 and https://github.com/NaturalHistoryMuseum/ckanext-query-dois/pull/12.

This PR implements the new templating functionality in the IVersionedDatastoreDownloads interface to provide a template for both plain and html download emails which includes a DOI that should be filled out by the query-dois plugin.