### PR TITLE
Stop converting string to bytes

### DIFF
--- a/ckanext/nhm/plugin.py
+++ b/ckanext/nhm/plugin.py
@@ -391,7 +391,7 @@ class NHMPlugin(SingletonPlugin, toolkit.DefaultDatasetForm):
             for d in descriptions:
                 if d['description'] == abstract:
                     d['descriptionType'] = 'Abstract'
-            metadata_dict['descriptions'] = descriptions
+
             if 'descriptions' in errors:
                 del errors['descriptions']
 

--- a/ckanext/nhm/plugin.py
+++ b/ckanext/nhm/plugin.py
@@ -380,12 +380,10 @@ class NHMPlugin(SingletonPlugin, toolkit.DefaultDatasetForm):
         with suppress(Exception):
             affiliation = pkg_dict.get('affiliation', None)
             if affiliation:
+                # add the common affiliation to all of the creators in the metadata dict
                 authors = metadata_dict.get('creators', [])
-                affiliated_authors = []
-                for a in authors:
-                    a['affiliations'] = affiliation
-                    affiliated_authors.append(a)
-                metadata_dict['creators'] = affiliated_authors
+                for author in authors:
+                    author['affiliations'] = affiliation
 
         with suppress(Exception):
             descriptions = metadata_dict.get('descriptions', [])

--- a/ckanext/nhm/plugin.py
+++ b/ckanext/nhm/plugin.py
@@ -4,6 +4,8 @@
 # This file is part of ckanext-nhm
 # Created by the Natural History Museum in London, UK
 import itertools
+from contextlib import suppress
+
 import logging
 import os
 from collections import OrderedDict
@@ -375,7 +377,7 @@ class NHMPlugin(SingletonPlugin, toolkit.DefaultDatasetForm):
         except Exception as e:
             errors['resourceType'] = e
 
-        try:
+        with suppress(Exception):
             affiliation = pkg_dict.get('affiliation', None)
             if affiliation:
                 authors = metadata_dict.get('creators', [])
@@ -384,10 +386,8 @@ class NHMPlugin(SingletonPlugin, toolkit.DefaultDatasetForm):
                     a['affiliations'] = affiliation
                     affiliated_authors.append(a)
                 metadata_dict['creators'] = affiliated_authors
-        except Exception:
-            pass  # just ignore this one
 
-        try:
+        with suppress(Exception):
             descriptions = metadata_dict.get('descriptions', [])
             abstract = pkg_dict.get('notes', None)
             for d in descriptions:
@@ -396,8 +396,6 @@ class NHMPlugin(SingletonPlugin, toolkit.DefaultDatasetForm):
             metadata_dict['descriptions'] = descriptions
             if 'descriptions' in errors:
                 del errors['descriptions']
-        except Exception as e:
-            pass
 
         return metadata_dict, errors
 

--- a/ckanext/nhm/plugin.py
+++ b/ckanext/nhm/plugin.py
@@ -381,7 +381,7 @@ class NHMPlugin(SingletonPlugin, toolkit.DefaultDatasetForm):
                 authors = metadata_dict.get('creators', [])
                 affiliated_authors = []
                 for a in authors:
-                    a['affiliations'] = affiliation.encode('unicode-escape')
+                    a['affiliations'] = affiliation
                     affiliated_authors.append(a)
                 metadata_dict['creators'] = affiliated_authors
         except Exception:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ ckan_extensions = OrderedDict([
     github('ckanext-dcat', '6b7ec505f303fb18e0eebcebf67130d36b3dca82', org='ckan'),
     github('ckanext-ckanpackager', 'v2.0.0'),
     github('ckanext-contact', 'v2.0.0'),
-    github('ckanext-doi', 'v3.0.0'),
+    github('ckanext-doi', 'v3.0.1'),
     github('ckanext-gallery', 'v2.0.0'),
     github('ckanext-gbif', 'v2.0.0'),
     github('ckanext-graph', 'v2.0.0'),


### PR DESCRIPTION
This is some kind of python2 -> python3 conversion failure on my part but it causes downstream issues because the affiliation values have to be strings, not bytes!

Additionally, tidied up some of the logic cause it was a little confusing to pick through.