### PR TITLE
Return gbif key references to specimen RDF

### DIFF
--- a/ckanext/nhm/dcat/specimen_records.py
+++ b/ckanext/nhm/dcat/specimen_records.py
@@ -280,8 +280,18 @@ class RecordGraphBuilder(object):
             for uri, term in terms.items():
                 if term in terms_to_skip:
                     continue
-                yield (self.record_ref, getattr(self.namespaces.dwc, term),
-                       Literal(self.record.get(term)))
+
+                if self.gbif_record is not None:
+                    gbif_key = self.gbif_record.get(f'{term}Key')
+                    if gbif_key:
+                        gbif_uri = URIRef(f'http://www.gbif.org/species/{gbif_key}')
+                        # add the GBIF species URI with label
+                        yield gbif_uri, self.namespaces.rdfs.label, Literal(self.record.get(term))
+                        # and associated our specimen object's DWC term with the GBIF URI
+                        yield self.record_ref, getattr(self.namespaces.dwc, term), URIRef(gbif_uri)
+                else:
+                    yield (self.record_ref, getattr(self.namespaces.dwc, term),
+                           Literal(self.record.get(term)))
 
         # retrieve the dynamic properties and yield them as one JSON dump
         dynamic_properties_dict = {}

--- a/ckanext/nhm/dcat/specimen_records.py
+++ b/ckanext/nhm/dcat/specimen_records.py
@@ -288,7 +288,7 @@ class RecordGraphBuilder(object):
                         # add the GBIF species URI with label
                         yield gbif_uri, self.namespaces.rdfs.label, Literal(self.record.get(term))
                         # and associated our specimen object's DWC term with the GBIF URI
-                        yield self.record_ref, getattr(self.namespaces.dwc, term), URIRef(gbif_uri)
+                        yield self.record_ref, getattr(self.namespaces.dwc, term), gbif_uri
                 else:
                     yield (self.record_ref, getattr(self.namespaces.dwc, term),
                            Literal(self.record.get(term)))


### PR DESCRIPTION
We used to do this and I inexplicably removed it when I refactored the RDF code. It's back now though!

As an aside - I'm not sure what the best way to represent this data in our RDF is. I've copied what was there before I removed it for now.