### PR TITLE
When asserting if something is downloadable, check if it's in the datastore

### DIFF
--- a/ckanext/nhm/lib/helpers.py
+++ b/ckanext/nhm/lib/helpers.py
@@ -796,7 +796,7 @@ def downloadable(resource):
     :returns: bool
 
     '''
-    return bool(resource['format'])
+    return bool(resource['format']) or resource.get('datastore_active', False)
 
 
 def is_sysadmin():


### PR DESCRIPTION
I'm still not convinced that using the format as part of this is correct and I'm sure there are edge cases that fail for it, but this at least gets over the non-downloadability of resources when they are posted directly to the portal using the API.

Fixes https://github.com/NaturalHistoryMuseum/ckanext-nhm/issues/539