### PR TITLE
Add /record route for all records

### DIFF
--- a/ckanext/nhm/lib/helpers.py
+++ b/ckanext/nhm/lib/helpers.py
@@ -1458,3 +1458,21 @@ def get_resource_size(resource_dict):
         prefixes = prefixes[1:]
         sz /= 1024
     return f'{round(sz)}{p}B'
+
+
+def get_record_permalink(resource_dict, record_dict, version=None, include_version=False):
+    try:
+        url = get_object_url(resource_dict['id'], record_dict['occurrenceID'], version, include_version)
+    except KeyError:
+        url_for_params = {
+            'resource_id': resource_dict['id'],
+            'record_id': record_dict['_id']
+        }
+        if include_version:
+            rounded_version = toolkit.get_action('datastore_get_rounded_version')({}, {
+                'resource_id': resource_dict['id'],
+                'version': version,
+            })
+            url_for_params['version'] = rounded_version
+        url = toolkit.url_for('record.permalink', qualified=True, **url_for_params)
+    return url

--- a/ckanext/nhm/theme/templates/doi/snippets/record_citation.html
+++ b/ckanext/nhm/theme/templates/doi/snippets/record_citation.html
@@ -2,8 +2,8 @@
 Renders a citation for a resource
 #}
 
-{% set latest = h.get_object_url(res.id, g.record_dict['occurrenceID'], include_version=False) %}
-{% set versioned = h.get_object_url(res.id, g.record_dict['occurrenceID'], g.version) %}
+{% set latest = h.get_record_permalink(res, g.record_dict) %}
+{% set versioned = h.get_record_permalink(res, g.record_dict, g.version, include_version=True) %}
 {% set retrieved = h.render_datetime(h.now(), date_format='%d %b %Y %H:%M:%S') %}
 
 {% asset 'ckanext-nhm/record-citation' %}

--- a/ckanext/nhm/theme/templates/record/specimen.html
+++ b/ckanext/nhm/theme/templates/record/specimen.html
@@ -29,10 +29,3 @@
         </li>
     {% endfor %}
 {% endblock %}
-
-{% block record_additional_information %}
-    {% if g.record_dict['occurrenceID']%}
-        {% snippet "doi/snippets/record_citation.html", pkg_dict=g.pkg, res=res %}
-    {% endif %}
-    {{ super() }}
-{% endblock %}

--- a/ckanext/nhm/theme/templates/record/view.html
+++ b/ckanext/nhm/theme/templates/record/view.html
@@ -142,7 +142,10 @@
     </div>
 </section>{% endblock %}{% endblock %}
 
-{% block primary_content %}{% block record_additional_information %}{% if res %}
+{% block primary_content %}
+{% block record_additional_information %}
+{% if res %}
+{% snippet "doi/snippets/record_citation.html", pkg_dict=g.pkg, res=res %}
 <section class="additional-info">
     {% block record_additional_information_inner %}
     <div class="module module-content">


### PR DESCRIPTION
Creates a shorter permalink for all records (not just specimens) of the form: /record/<resource_id>/<record_id>/<version>. Also enables the URLs in the footer for all records.

Closes #545 