### PR TITLE
Add a string filter before truncating record title

### DIFF
--- a/ckanext/nhm/theme/templates/record/view.html
+++ b/ckanext/nhm/theme/templates/record/view.html
@@ -15,7 +15,7 @@
 <li>{% link_for h.resource_display_name(res)|truncate(40), named_route='resource.read', id=g.pkg.name,
     resource_id=res.id %}
 </li>
-<li class="active"><a href="">{{ g.record_title|truncate(30) }}</a></li>{% endblock %}
+<li class="active"><a href="">{{ g.record_title|string|truncate(30) }}</a></li>{% endblock %}
 
 {% block pre_primary %}
 


### PR DESCRIPTION
In case record title is an integer (or something else that's not a string).