### PR TITLE
Tags and formats

### DIFF
--- a/ckanext/nhm/logic/action.py
+++ b/ckanext/nhm/logic/action.py
@@ -207,6 +207,13 @@ def package_update(next_action, context, pkg_dict):
 
 
 @toolkit.chained_action
+def resource_create(next_action, context, res_dict):
+    # force uppercase and trim '.' for file formats
+    res_dict['format'] = res_dict.get('format', '').upper().strip('.')
+    return next_action(context, res_dict)
+
+
+@toolkit.chained_action
 def resource_update(next_action, context, res_dict):
     # force uppercase and trim '.' for file formats
     res_dict['format'] = res_dict.get('format', '').upper().strip('.')

--- a/ckanext/nhm/plugin.py
+++ b/ckanext/nhm/plugin.py
@@ -4,18 +4,16 @@
 # This file is part of ckanext-nhm
 # Created by the Natural History Museum in London, UK
 import itertools
-from contextlib import suppress
-
 import logging
 import os
 from collections import OrderedDict
+from contextlib import suppress
 from pathlib import Path
 
 import ckan.model as model
 import ckanext.nhm.lib.helpers as helpers
 import ckanext.nhm.logic.action as nhm_action
 import ckanext.nhm.logic.schema as nhm_schema
-import requests
 from beaker.cache import cache_managers, cache_regions
 from ckan.lib.helpers import literal
 from ckan.plugins import SingletonPlugin, implements, interfaces, toolkit
@@ -81,7 +79,9 @@ class NHMPlugin(SingletonPlugin, toolkit.DefaultDatasetForm):
             'record_show': nhm_action.record_show,
             'object_rdf': nhm_action.object_rdf,
             'get_permanent_url': nhm_action.get_permanent_url,
-            'user_show': nhm_action.user_show
+            'user_show': nhm_action.user_show,
+            'package_update': nhm_action.package_update,
+            'resource_update': nhm_action.resource_update
         }
 
     ## IClick

--- a/ckanext/nhm/plugin.py
+++ b/ckanext/nhm/plugin.py
@@ -81,6 +81,7 @@ class NHMPlugin(SingletonPlugin, toolkit.DefaultDatasetForm):
             'get_permanent_url': nhm_action.get_permanent_url,
             'user_show': nhm_action.user_show,
             'package_update': nhm_action.package_update,
+            'resource_create': nhm_action.resource_create,
             'resource_update': nhm_action.resource_update
         }
 


### PR DESCRIPTION
Force casing and clean strings for tags and formats when saving packages and resources.
Uppercase with no leading/trailing '.' for formats, lowercase for tags with no duplication of standard category tags (e.g. Collections, Citizen Science, etc).