### PR TITLE
Add css scroll snap to thumbnail carousel

### DIFF
--- a/ckanext/nhm/theme/assets/less/beetle-iiif.less
+++ b/ckanext/nhm/theme/assets/less/beetle-iiif.less
@@ -121,11 +121,13 @@ button.btn[disabled].biiif-button {
   display: flex;
   overflow-x: auto;
   flex-wrap: nowrap;
+  scroll-snap-type: x proximity;
 }
 
 .biiif-thumbnail-container {
   text-align: center;
   padding: 10px;
+  scroll-snap-align: start;
 
   &.active {
     background-color: @primary6;


### PR DESCRIPTION
Provides a nicer user experience by snapping the thumbnails in the carousel on scroll to the start of each.