### PR TITLE
Slug generator stats graph

### DIFF
--- a/ckanext/nhm/theme/assets/scripts/modules/graphs.js
+++ b/ckanext/nhm/theme/assets/scripts/modules/graphs.js
@@ -23,9 +23,9 @@ ckan.module('stats_graphs', function ($) {
             function drawGraph() {
                 graphBox.empty();
                 const width = graphBox.width();
-                const height = 500;
-                const marginH = 50;
-                const marginV = 20;
+                const height = graphBox.height() > 0 ? graphBox.height() : 500;
+                const marginH = Math.round(height * 0.1);
+                const marginV = Math.round(height * 0.04);
 
                 let svg = d3.select('#graph-box').append('svg').attr('width', width)
                             .attr('height', height)

--- a/ckanext/nhm/theme/templates/search/slugerator.html
+++ b/ckanext/nhm/theme/templates/search/slugerator.html
@@ -1,0 +1,13 @@
+{% ckan_extends %}
+
+{% block slug_stats %}
+{% asset "ckanext-nhm/stats-graphs" %}
+<div id="stats-total-slugs">
+    <b>Query slugs in use</b>
+    <br><br>
+    <div data-module="stats_graphs" data-module-data="{{ h.dump_json(g.graph_data) }}"
+         id="graph-box" style="width: 100%; height: 300px;">
+    </div>
+</div>
+{{ super() }}
+{% endblock %}


### PR DESCRIPTION
Adds a small graph to the new slugerator page.

Depends on NaturalHistoryMuseum/ckanext-versioned-datastore#74