### PR TITLE
Change how contact requests are routed

### DIFF
--- a/ckanext/nhm/lib/mail.py
+++ b/ckanext/nhm/lib/mail.py
@@ -1,0 +1,64 @@
+from ckan import model
+from ..settings import COLLECTION_CONTACTS
+
+
+def create_indexlots_email(mail_dict: dict):
+    """
+    Updates the given mail dict with the right details to deal with an index lots
+    contact request.
+
+    :param mail_dict: the mail dict to update
+    """
+    mail_dict['subject'] = 'Collection Index lot enquiry'
+    mail_dict['recipient_email'] = COLLECTION_CONTACTS['Insects']
+    mail_dict['recipient_name'] = 'Insects'
+
+
+def create_department_email(mail_dict: dict, department: str):
+    """
+    Updates the given mail dict with the right details to deal with a request to contact
+    the given department.
+
+    :param mail_dict: the mail dict to update
+    :param department: the department to contact
+    """
+    try:
+        mail_dict['recipient_email'] = COLLECTION_CONTACTS[department]
+    except KeyError:
+        # Other/unknown etc., - so don't set recipient email
+        mail_dict['body'] += f'\nDepartment: {department}\n'
+    else:
+        mail_dict['recipient_name'] = department
+        mail_dict['body'] += (
+            f'\nThe contactee has chosen to send this to the {department} '
+            f'department. Our apologies if this enquiry isn\'t '
+            f'relevant - please forward this onto data@nhm.ac.uk '
+            f'and we will respond.\nMany thanks, Data Portal '
+            f'team\n\n'
+        )
+
+
+def create_package_email(mail_dict: dict, package: dict):
+    """
+    Updates the given mail dict with the right details to contact the owner of the given
+    package.
+
+    :param mail_dict: the mail dict to update
+    :param package: the package dict
+    """
+    # Load the user - using model rather user_show API which loads all the
+    # users packages etc.,
+    user_obj = model.User.get(package['creator_user_id'])
+    mail_dict['recipient_name'] = user_obj.fullname or user_obj.name
+    # Update send to with creator username
+    mail_dict['recipient_email'] = user_obj.email
+
+    pkg_title = package['title'] or package['name']
+    mail_dict['subject'] = f'Message regarding dataset: {pkg_title}'
+    mail_dict['body'] += (
+        '\n\nYou have been sent this enquiry via the data portal '
+        f'as you are the author of dataset {pkg_title}.  Our apologies '
+        'if this isn\'t relevant - please forward this onto '
+        'data@nhm.ac.uk and we will respond.\nMany thanks, '
+        'Data Portal team\n\n'
+    )

--- a/ckanext/nhm/plugin.py
+++ b/ckanext/nhm/plugin.py
@@ -366,8 +366,8 @@ class NHMPlugin(SingletonPlugin, toolkit.DefaultDatasetForm):
                     f'and we will respond.\nMany thanks, Data Portal '
                     f'team\n\n'
                 )
-                # If we have a package ID, load the package
         elif package_id:
+            # If we have a package ID, load the package
             package_dict = toolkit.get_action('package_show')(
                 context, {'id': package_id}
             )

--- a/ckanext/nhm/plugin.py
+++ b/ckanext/nhm/plugin.py
@@ -320,10 +320,6 @@ class NHMPlugin(SingletonPlugin, toolkit.DefaultDatasetForm):
 
         context = {'user': toolkit.c.user or toolkit.c.author}
 
-        # URL to provide as link to contact email body
-        # Over written by linking to record / resource etc., - see below
-        url = None
-
         # Has the user selected a department
         department = data_dict.get('department', None)
 

--- a/ckanext/nhm/plugin.py
+++ b/ckanext/nhm/plugin.py
@@ -348,7 +348,6 @@ class NHMPlugin(SingletonPlugin, toolkit.DefaultDatasetForm):
                         qualified=True,
                     )
 
-        # If this is an index lot enquiry, send to entom
         if package_name == 'collection-indexlots':
             create_indexlots_email(mail_dict)
         elif department:
@@ -360,8 +359,8 @@ class NHMPlugin(SingletonPlugin, toolkit.DefaultDatasetForm):
         for i, url in urls.items():
             mail_dict['body'] += f'\n{i.title()}: {url}'
 
-        # If this is being directed to someone other than @daat@nhm.ac.uk
-        # Ensure data@nhm.ac.uk is copied in
+        # If this is being directed to someone other than data@nhm.ac.uk ensure
+        # data@nhm.ac.uk is copied in
         if mail_dict['recipient_email'] != 'data@nhm.ac.uk':
             mail_dict['headers']['cc'] = 'data@nhm.ac.uk'
         return mail_dict


### PR DESCRIPTION
Instead of just emailing the creator of the dataset, we now email all the admins with the creator as a backup if no admins were found. Because ckan, we send an individual email to each dataset owner.

Depends on https://github.com/NaturalHistoryMuseum/ckanext-contact/pull/31

Closes #630