### PR TITLE
Old/non-current version notice on record pages

### DIFF
--- a/ckanext/nhm/theme/assets/less/nhm.less
+++ b/ckanext/nhm/theme/assets/less/nhm.less
@@ -334,6 +334,14 @@ body {
   padding-right: 10px;
 }
 
+.margin-top {
+  margin-top: 10px;
+}
+
+.margin-bottom {
+  margin-bottom: 10px;
+}
+
 .pagination-wrapper .pagination {
   // this is for the numbered blobs at the bottom of, e.g. the datasets list, not the list view one
   border: none !important;
@@ -1859,7 +1867,7 @@ tr.empty {
 .alert-error {
   background-color: @warning5;
   color: @warning2;
-  padding: 3px;
+  padding: 5px;
   border: 1px dashed @warning4;
 }
 
@@ -1869,6 +1877,13 @@ tr.empty {
 
 .alert .close {
   opacity: 0.8;
+}
+
+.alert-info {
+  background-color: tint(@primary6, 70%);
+  color: @baseTextColor;
+  padding: 5px;
+  border: 1px dashed @primary5;
 }
 
 // SELECT2 -----------------------------------------------------------------------------------------

--- a/ckanext/nhm/theme/templates/record/view.html
+++ b/ckanext/nhm/theme/templates/record/view.html
@@ -26,6 +26,14 @@
         {% block page_header %}
         <header class="page-header">
             <div class="row flex-container flex-wrap flex-wrap-spacing flex-between flex-stretch-first flex-reverse">
+                {% if g.version and h.latest_item_version(resource_id=res.id, record_id=rec['_id']) != g.version %}
+                <div class="col-md-12 full-width alert-info margin-bottom">
+                    <p><b>This is not the most recent version of this record.</b></p>
+                    <p>This version is from {{ h.get_version_date(g.version) }}.</p>
+                    <p>If you have followed a link from a citation, this may be what you want. If it's not, you can <a href="{{ h.get_record_permalink(res, g.record_dict) }}">view the latest version here</a>.</p>
+                    <p class="no-margin">Please be aware that images on versions from before January 2022 may no longer be accessible.</p>
+                </div>
+                {% endif %}
                 <div class="col-md-6">
                     <ul class="list-unstyled flex-container flex-smallwrap flex-right inline-list-pad">
                         <li>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "ckanext-ldap~=3.2.0",
     "ckanext-query-dois~=3.0.0",
     "ckanext-statistics~=3.1.0",
-    "ckanext-versioned-datastore~=4.1.0"
+    "ckanext-versioned-datastore~=4.2.0"
     # this also depends on ckanext-dcat==1.3.0 (see readme)
 ]
 


### PR DESCRIPTION
e.g.
![image](https://user-images.githubusercontent.com/23579762/222216544-0a0f712b-f901-4db8-868f-4e748b83a7fa.png)

Depends on NaturalHistoryMuseum/ckanext-versioned-datastore#99
