### PR TITLE
chore(contact form): remove EEES option and redirect ES FIP

### DIFF
--- a/ckanext/nhm/settings.py
+++ b/ckanext/nhm/settings.py
@@ -10,8 +10,7 @@ from collections import OrderedDict
 COLLECTION_CONTACTS = OrderedDict(
     [
         ('Algae, Fungi & Plants', 'm.carine@nhm.ac.uk'),
-        ('Economic & Environmental Earth Sciences', 'g.miller@nhm.ac.uk'),
-        ('Fossil Invertebrates & Plants', 'z.hughes@nhm.ac.uk'),
+        ('Fossil Invertebrates & Plants', 'g.miller@nhm.ac.uk'),
         ('Fossil Vertebrates & Anthropology', 'h.bonney@nhm.ac.uk'),
         ('Insects', 'g.broad@nhm.ac.uk'),
         ('Invertebrates', 'm.lowe@nhm.ac.uk'),


### PR DESCRIPTION
Updated in response to a request from Giles M. 

'Economic & Environmental Earth Sciences' doesn't exist as a separate entity within ES any more, so this option should be removed from the contact form to encourage users to direct their queries to the relevant ES curation team. Giles should also replace Zoe as the recipient of any emails aimed at the Fossil Inverts & Plants team. 