### PR TITLE
fix: do not propogate errors from phenome10k api call

### DIFF
--- a/ckanext/nhm/lib/external_links.py
+++ b/ckanext/nhm/lib/external_links.py
@@ -141,7 +141,10 @@ def get_gbif_links(record):
             )
         )
     all_links.append(('GBIF', 'https://gbif.org/favicon.ico', gbif_links))
-    p10k_link = P10k.get_link(gbif_record)
-    if p10k_link:
-        all_links.append((P10k.name, P10k.site_icon_url, [p10k_link]))
+    try:
+        p10k_link = P10k.get_link(gbif_record)
+        if p10k_link:
+            all_links.append((P10k.name, P10k.site_icon_url, [p10k_link]))
+    except requests.RequestException:
+        pass
     return all_links


### PR DESCRIPTION
If the call fails, this then results in the record page not loading. We should add defenses around all the external calls in this module, but this is the most pressing immediate need and hence they will be done in the normal dev release cycle, not patch.