### PR TITLE
Refactor external links and make them all safer

### DIFF
--- a/ckanext/nhm/lib/external_links.py
+++ b/ckanext/nhm/lib/external_links.py
@@ -60,6 +60,9 @@ def _get_gbif_record(occurrence_id: str, institution_code: str) -> Optional[dict
     :param occurrence_id: an occurrence ID
     :param institution_code: an institution code, this will probably be NHMUK really
     """
+    if occurrence_id is None or institution_code is None:
+        return None
+
     r = requests.get(
         "https://api.gbif.org/v1/occurrence/search",
         params={

--- a/ckanext/nhm/lib/external_links.py
+++ b/ckanext/nhm/lib/external_links.py
@@ -111,10 +111,13 @@ class Phenome10kSite(Site):
             gbif_record = _get_gbif_record(
                 record.get("occurrenceID"), record.get("institutionCode", "NHMUK")
             )
-            if gbif_record and "key" in record:
+            if gbif_record and "key" in gbif_record:
                 p10k_record = _get_phenome10k_record(gbif_record["key"])
-                links.append(Link(p10k_record["scientific_name"], p10k_record["url"]))
-        except KeyError or requests.RequestException:
+                if p10k_record:
+                    links.append(
+                        Link(p10k_record["scientific_name"], p10k_record["url"])
+                    )
+        except (requests.RequestException, KeyError):
             pass
         return links
 

--- a/ckanext/nhm/lib/external_links.py
+++ b/ckanext/nhm/lib/external_links.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 from typing import Callable
 
 import requests
+
 from ckanext.nhm.lib.taxonomy import extract_ranks
 
 

--- a/ckanext/nhm/lib/external_links.py
+++ b/ckanext/nhm/lib/external_links.py
@@ -11,7 +11,7 @@ import requests
 from ckanext.nhm.lib.taxonomy import extract_ranks
 
 
-class Site(object):
+class Site:
     def __init__(
         self,
         name,

--- a/ckanext/nhm/lib/external_links.py
+++ b/ckanext/nhm/lib/external_links.py
@@ -85,7 +85,7 @@ class Phenome10kSite(Site):
         links = []
         try:
             gbif_record = _get_gbif_record(
-                record.get("occurrenceID"), record.get("institutionCode")
+                record.get("occurrenceID"), record.get("institutionCode", "NHMUK")
             )
             if gbif_record and "key" in record:
                 gbif_key = gbif_record.get("key")
@@ -117,7 +117,7 @@ class GBIFSite(Site):
 
         try:
             gbif_record = _get_gbif_record(
-                record.get("occurrenceID"), record.get("institutionCode")
+                record.get("occurrenceID"), record.get("institutionCode", "NHMUK")
             )
             if gbif_record:
                 links_parts = [

--- a/ckanext/nhm/lib/helpers.py
+++ b/ckanext/nhm/lib/helpers.py
@@ -20,6 +20,7 @@ from ckan.lib.helpers import literal
 from ckan.plugins import toolkit
 from ckanext.gbif.lib.errors import GBIF_ERRORS
 from ckanext.nhm.lib import external_links
+from ckanext.nhm.lib.external_links import Link, Site
 from ckanext.nhm.lib.form import list_to_form_options
 from ckanext.nhm.lib.resource_view import (
     resource_view_get_filter_options,
@@ -31,7 +32,7 @@ from datetime import datetime
 from jinja2.filters import do_truncate
 from lxml import etree, html
 from operator import itemgetter
-from typing import Optional
+from typing import Optional, List, Tuple
 from urllib.parse import quote
 
 log = logging.getLogger(__name__)
@@ -1321,19 +1322,16 @@ def get_latest_update_for_package_resources(pkg_dict, date_format=None):
     return toolkit._('unknown')
 
 
-def get_external_links(record):
+def get_external_sites(record: dict) -> List[Site]:
     """
     Helper called on collection record pages (i.e. records in the specimens, indexlots
-    or artefacts resources) which is expected to return a list of tuples. Each tuple
-    provides a title and a list of links, respectively, which are relevant to the
-    record.
+    or artefacts resources) which is expected to return a list of Site objects. From
+    these sites, links can be generated which are relevant to the record.
 
-    :param record:
-    :return:
+    :param record: a record dict
+    :return: a list of Site objects
     """
-    taxonomy_search_links = external_links.get_taxonomy_searches(record)
-    gbif_links = external_links.get_gbif_links(record)
-    return taxonomy_search_links + gbif_links
+    return external_links.get_sites(record)
 
 
 def render_epoch(

--- a/ckanext/nhm/lib/helpers.py
+++ b/ckanext/nhm/lib/helpers.py
@@ -4,23 +4,29 @@
 # This file is part of ckanext-nhm
 # Created by the Natural History Museum in London, UK
 
-from collections import OrderedDict, defaultdict
-
 import itertools
 import json
 import logging
 import operator
-import os
 import re
 import time
+from collections import OrderedDict, defaultdict
+from datetime import datetime
+from operator import itemgetter
+from typing import List
+from urllib.parse import quote
+
 from beaker.cache import cache_region
+from jinja2.filters import do_truncate
+from lxml import etree, html
+
 from ckan import model
 from ckan.lib import helpers as core_helpers
 from ckan.lib.helpers import literal
 from ckan.plugins import toolkit
 from ckanext.gbif.lib.errors import GBIF_ERRORS
 from ckanext.nhm.lib import external_links
-from ckanext.nhm.lib.external_links import Link, Site
+from ckanext.nhm.lib.external_links import Site
 from ckanext.nhm.lib.form import list_to_form_options
 from ckanext.nhm.lib.resource_view import (
     resource_view_get_filter_options,
@@ -28,12 +34,6 @@ from ckanext.nhm.lib.resource_view import (
 )
 from ckanext.nhm.logic.schema import DATASET_TYPE_VOCABULARY, UPDATE_FREQUENCIES
 from ckanext.nhm.settings import COLLECTION_CONTACTS
-from datetime import datetime
-from jinja2.filters import do_truncate
-from lxml import etree, html
-from operator import itemgetter
-from typing import Optional, List, Tuple
-from urllib.parse import quote
 
 log = logging.getLogger(__name__)
 

--- a/ckanext/nhm/theme/templates/record/snippets/external_links.html
+++ b/ckanext/nhm/theme/templates/record/snippets/external_links.html
@@ -5,23 +5,30 @@
         <div class="module-content external-links">
             <h3>{{ _('External Links') }}</h3>
             {% block external_links_content %}
-                {% set external_links = h.get_external_links(record) %}
-                {% if external_links %}
-                    {% for text, icon, links in external_links %}
-                        <div class="external-link-parent">
-                            <div class="external-link-name">
-                                <img width="16" height="16" src="{{ icon }}" alt="{{ text }} icon">&nbsp;<span>{{ text }}&nbsp;<i class="fas fa-caret-down"></i></span>
+                {% set external_sites = h.get_external_sites(record) %}
+                {% if external_sites %}
+                    {% for site in external_sites %}
+                        {% set links = site.get_links(record) %}
+                        {% if links %}
+                            <div class="external-link-parent">
+                                <div class="external-link-name">
+                                    <img width="16" height="16"
+                                         src="{{ site.icon_url }}"
+                                         alt="{{ site.name }} icon">&nbsp;<span>{{ site.name }}&nbsp;<i
+                                    class="fas fa-caret-down"></i></span>
+                                </div>
+                                <ul>
+                                    {% for link in links %}
+                                        <li class="external-link-child">
+                                            <a href="{{ link.url }}" target="_blank"
+                                               class="external">
+                                                {{ link.text }}
+                                            </a>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
                             </div>
-                            <ul>
-                                {% for link_text, link in links %}
-                                    <li class="external-link-child">
-                                        <a href="{{ link }}" target="_blank" class="external">
-                                            {{ link_text }}
-                                        </a>
-                                    </li>
-                                {% endfor %}
-                            </ul>
-                        </div>
+                        {% endif %}
                     {% endfor %}
                 {% endif %}
             {% endblock %}

--- a/tests/unit/test_external_links.py
+++ b/tests/unit/test_external_links.py
@@ -1,0 +1,41 @@
+from unittest.mock import MagicMock
+
+from ckanext.nhm.lib.external_links import get_sites, RankedTemplateSite, Link
+
+
+class TestGetSites:
+    def test_no_collection_code_does_not_fail(self):
+        # just call the function and if it raises an exception then it has failed the
+        # test
+        get_sites({})
+        get_sites({"collectionCode": None})
+
+    def test_collection_codes_return_sites(self):
+        for code in ["BOT", "MIN", "PAL", "ZOO", "BMNH(E)"]:
+            assert len(get_sites({"collectionCode": code})) > 0
+
+    def test_invalid_collection_code_returns_no_sites(self):
+        assert len(get_sites({"collectionCode": "bananas"})) == 0
+
+
+class TestRankedTemplateSite:
+    def test_has_rank_data(self):
+        template = "beans/{}"
+        templated = RankedTemplateSite(MagicMock(), MagicMock(), template)
+
+        record = {
+            "kingdom": "a kingdom",
+            "family": "a family",
+        }
+        links = templated.get_links(record)
+        assert len(links) == 2
+        assert links[0] == Link("a kingdom", template.format("a kingdom"))
+        assert links[1] == Link("a family", template.format("a family"))
+
+    def test_no_rank_data(self):
+        template = "beans/{}"
+        templated = RankedTemplateSite(MagicMock(), MagicMock(), template)
+
+        record = {}
+        links = templated.get_links(record)
+        assert len(links) == 0


### PR DESCRIPTION
This set of commits refactors the external links module to make it a bit more uniform and adds protections were necessary to avoid API calls to other sites from causing record page load errors. This is an extension of the work done in #670.