### PR TITLE
Handle empty datastore resources

### DIFF
--- a/ckanext/nhm/lib/helpers.py
+++ b/ckanext/nhm/lib/helpers.py
@@ -1257,14 +1257,18 @@ def _get_latest_update(package_or_resource_dicts):
     latest_date = None
     for package_or_resource_dict in package_or_resource_dicts:
         dates = [package_or_resource_dict.get(field, None) for field in fields]
-        if package_or_resource_dict.get(
-            'datastore_active', False
-        ):  # i.e. a datastore resource
+        
+        # check if this is a datastore resource
+        if package_or_resource_dict.get('datastore_active', False):
             pkg_version = get_rounded_version(
                 {}, {'resource_id': package_or_resource_dict['id']}
             )
+            # could be a datastore resource with no records, ignore if so
+            if pkg_version is None:
+                continue
             version_date = datetime.fromtimestamp(pkg_version / 1000)
             dates.append(version_date)
+        
         for datestamp in dates:
             date = core_helpers._datestamp_to_datetime(datestamp)
             if date is not None and (latest_date is None or date > latest_date):


### PR DESCRIPTION
If a resource is datastore_active but has no records in it then the _get_latest_update function errors out when trying to divide the `pkg_version` (which is `None`) by 1000). A live example can be found here: https://data.nhm.ac.uk/dataset/baleen-stable-isotope-data