### PR TITLE
Patch release 2023-10-05

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,16 +24,16 @@ dependencies = [
     "cachetools>=4.2.4",
     "lxml>=4.4.2",
     "elasticsearch-dsl>=6.0.0,<7.0.0",
-    "ckanext-contact~=2.3.0",
-    "ckanext-doi~=3.1.0",
-    "ckanext-gallery~=2.2.0",
-    "ckanext-gbif~=2.1.0",
-    "ckanext-graph~=2.1.0",
-    "ckanext-iiif~=3.0.1",
-    "ckanext-ldap~=3.2.0",
-    "ckanext-query-dois~=4.0.0",
-    "ckanext-statistics~=3.1.0",
-    "ckanext-versioned-datastore~=5.1.0"
+    "ckanext-contact>=2.3.0",
+    "ckanext-doi>=3.1.0",
+    "ckanext-gallery>=2.2.0",
+    "ckanext-gbif>=2.1.0",
+    "ckanext-graph>=2.1.0",
+    "ckanext-iiif>=3.0.1",
+    "ckanext-ldap>=3.2.0",
+    "ckanext-query-dois>=4.0.0",
+    "ckanext-statistics>=3.1.0",
+    "ckanext-versioned-datastore>=5.1.0"
     # this also depends on ckanext-dcat==1.3.0 (see readme)
 ]
 


### PR DESCRIPTION
Changes the version specifiers for NHM CKAN extensions in pyproject.toml from `~=` to `>=`. This should avoid having to do unnecessary releases just to increase a version number when it doesn't actually affect this extension.

This should be fairly safe to do for our own extensions. If this extension _does_ use new functionality from a new release, the version specifier should still be increased. This just avoids having to do it when it doesn't matter.