### PR TITLE
Include `base/view-filters` in all assets that require it to ensure `ckan.views` is available

### DIFF
--- a/ckanext/nhm/theme/assets/webassets.yml
+++ b/ckanext/nhm/theme/assets/webassets.yml
@@ -42,6 +42,7 @@ slickgrid-js:
     preload:
       - base/main
       - base/ckan
+      - base/view-filters
   contents:
     - scripts/slickgrid.js
 
@@ -57,6 +58,7 @@ resource-view-field-filters:
   extra:
     preload:
       - base/main
+      - base/view-filters
   contents:
     - scripts/modules/resource-view-field-filters.js
 
@@ -66,6 +68,7 @@ resource-view-filter-options:
   extra:
     preload:
       - base/main
+      - base/view-filters
   contents:
     - scripts/modules/resource-view-filter-options.js
 


### PR DESCRIPTION
This fixes the old gallery view not being interactive. I'm not exactly sure why but I think it caused some of our code to fail to initialise properly and then the click events were just being missed. Not sure why this suddenly stopped working either? Bit weird but heyho. It is likely not all of these assets need base/view-filters, I just added it to every asset which included a JS file which references ckan.views to be safe.

Closes: #723