### PR TITLE
Use IIIF endpoints for all IIIF images, not just MSS 

### DIFF
--- a/ckanext/nhm/lib/record.py
+++ b/ckanext/nhm/lib/record.py
@@ -98,16 +98,22 @@ class RecordImage:
     is_mss_image: bool = False
 
     @property
+    def is_iiif_image(self) -> bool:
+        return self.is_mss_image or self.url.startswith(
+            toolkit.config.get('ckanext.iiif.image_server_url')
+        )
+
+    @property
     def download_url(self) -> str:
-        return f'{self.url}/original' if self.is_mss_image else self.url
+        return f'{self.url}/original' if self.is_iiif_image else self.url
 
     @property
     def preview_url(self) -> str:
-        return f'{self.url}/preview' if self.is_mss_image else self.url
+        return f'{self.url}/preview' if self.is_iiif_image else self.url
 
     @property
     def thumbnail_url(self) -> str:
-        return f'{self.url}/thumbnail' if self.is_mss_image else self.url
+        return f'{self.url}/thumbnail' if self.is_iiif_image else self.url
 
 
 class Record:


### PR DESCRIPTION
Adds `is_iiif_image` to `RecordImage` that checks:
1. is it an MSS image (i.e. is it a collection image)
2. if not, does the URL start with the IIIF server URL (`ckanext.iiif.image_server_url`)

If True, adds the `/original`, `/preview`, and `/thumbnail` endings to the URL as necessary.