### PR TITLE
More links to the LIV

### DIFF
--- a/ckanext/nhm/routes/liv.py
+++ b/ckanext/nhm/routes/liv.py
@@ -10,9 +10,14 @@ blueprint = Blueprint(name='liv', import_name=__name__, url_prefix='/image-viewe
 
 
 @blueprint.route('/')
-@blueprint.route('/<path:mode>')
-def index(mode=''):
+@blueprint.route('/<mode>')
+@blueprint.route('/<mode>/<path:mode_params>')
+def index(mode='', mode_params=''):
     """
     Render the image viewer page.
     """
-    return toolkit.render('liv.html', extra_vars={'mode': mode})
+    # the template doesn't actually do anything with the args but we may as well pass
+    # them in anyway
+    return toolkit.render(
+        'liv.html', extra_vars={'mode': mode, 'mode_params': mode_params}
+    )

--- a/ckanext/nhm/theme/templates/beetle_iiif.html
+++ b/ckanext/nhm/theme/templates/beetle_iiif.html
@@ -18,7 +18,7 @@
     {% asset 'ckanext-nhm/beetle-iiif-css' %}
     {% asset 'ckanext-nhm/beetle-iiif-js' %}
     <div class="biiif-deprecation-banner">
-        You can view this dataset with our <a href="{{ h.url_for('liv.index', mode='resource/' + h.get_beetle_iiif_resource_id()) }}">new image viewer</a>.
+        You can view this dataset with our <a href="{{ h.url_for('liv.index', mode='resource', mode_params=h.get_beetle_iiif_resource_id()) }}">new image viewer</a>.
     </div>
     <div id="beetle-iiif-app" data-resource-id="{{ h.get_beetle_iiif_resource_id() }}">
     </div>

--- a/ckanext/nhm/theme/templates/package/resource_read.html
+++ b/ckanext/nhm/theme/templates/package/resource_read.html
@@ -22,6 +22,12 @@
                             {% if 'datastore' in g.plugins and res.datastore_active %}
                                 <li>{% snippet 'package/snippets/data_api_button.html', resource=res, datastore_root_url=g.datastore_api %}</li>
                             {% endif %}
+                            {% if res._image_field %}
+                            <li><a class="btn btn-primary"
+                                   href="{{ h.url_for('liv.index', mode='resource', mode_params=res.id) }}">
+                                <i class="fas fa-images"></i> {{ _('Open in image viewer') }}
+                            </a></li>
+                            {% endif %}
                             <li>{% snippet "contact/snippets/modal_link.html", pkg=g.pkg, res=res %}</li>
                         {% endblock %}
                     </ul>

--- a/ckanext/nhm/theme/templates/record/view.html
+++ b/ckanext/nhm/theme/templates/record/view.html
@@ -156,8 +156,8 @@
             View Manifest
         </a> |
         <a target="_blank"
-           href="https://projectmirador.org/embed/?iiif-content={{ iiif_manifest_url }}">
-            View in Mirador
+           href="{{ h.url_for('liv.index', mode='record', mode_params=res.id ~ '/' ~ rec['_id']) }}">
+            View in Image Viewer
         </a>
         {% endif %} {% endblock %}
 


### PR DESCRIPTION
- made it slightly easier to construct LIV links with `h.url_for` (though for anything beyond 1 mode parameter, the items still have to be joined with `/`)
- changed mirador link on record page to LIV link
- added LIV link to main resource page