### PR TITLE
Enable maintainer/contact email

### DIFF
--- a/ckanext/nhm/lib/mail.py
+++ b/ckanext/nhm/lib/mail.py
@@ -74,6 +74,9 @@ def get_package_owners(package: dict) -> List[Recipient]:
 
     :param package: the package dict
     """
+    maintainer_name = package.get('maintainer', 'Maintainer')
+    maintainer_email = package.get('maintainer_email')
+
     collaborators = toolkit.get_action('package_collaborator_list')(
         # ignore auth to ensure we can access the list of collaborators
         {'ignore_auth': True},
@@ -81,14 +84,19 @@ def get_package_owners(package: dict) -> List[Recipient]:
         {'id': package['id'], 'capacity': 'admin'},
     )
 
-    recipient_ids = []
-    if collaborators:
-        recipient_ids.extend(collaborator['user_id'] for collaborator in collaborators)
+    recipients = []
+    if maintainer_email:
+        recipients.append(Recipient(maintainer_name, maintainer_email))
+    elif collaborators:
+        recipients = [
+            Recipient.from_user_id(collaborator['user_id'])
+            for collaborator in collaborators
+        ]
     else:
-        # if there aren't any collaborators, use the creator
-        recipient_ids.append(package['creator_user_id'])
+        # if there's no maintainer and there aren't any collaborators, use the creator
+        recipients.append(Recipient.from_user_id(package['creator_user_id']))
 
-    return list(map(Recipient.from_user_id, recipient_ids))
+    return recipients
 
 
 def create_package_email(mail_dict: dict, package: dict):

--- a/ckanext/nhm/theme/assets/less/nhm.less
+++ b/ckanext/nhm/theme/assets/less/nhm.less
@@ -1387,6 +1387,7 @@ iframe {
   margin: 5px 0;
 }
 
+.info-block,
 .form-group .info-block {
   color: @grey4;
   font-size: @font-size-body-s;
@@ -1394,6 +1395,11 @@ iframe {
   a {
     color: @primary3;
   }
+}
+
+.form-group + .info-block {
+  margin-top: -25px; // the margin-bottom for .form-group is 30px
+  margin-bottom: 30px;
 }
 
 input[type='radio'],

--- a/ckanext/nhm/theme/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/nhm/theme/templates/package/snippets/package_metadata_fields.html
@@ -26,8 +26,8 @@
         {{ super() }}
     {% endblock %}
 
-    {{ form.info("What time period does this dataset cover? If not applicable, leave blank.", inline=True) }}
     {{ form.input('temporal_extent', label=_('Temporal extent'), id='field-temporal-extent', placeholder=_('1970 - 1985'), value=data.temporal_extent, error=errors.temporal_extent, classes=['control-medium']) }}
+    {{ form.info("What time period does this dataset cover? If not applicable, leave blank.", inline=True) }}
 
     {{ form.select('update_frequency', label=_('Update frequency'), id='field-update-frequency', options=h.form_select_update_frequency_options(), selected=data.update_frequency, error=errors.update_frequency, classes=['control-medium']) }}
     {#  TODO: Add map to pick spatial extent - hidden for non sysadmin until then  #}

--- a/ckanext/nhm/theme/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/nhm/theme/templates/package/snippets/package_metadata_fields.html
@@ -13,6 +13,11 @@
 {% endblock %}
 
 {% block package_metadata_fields_maintainer %}
+{{ form.input('maintainer_email', label=_('Contact email'), id='field-maintainer-email', placeholder=_('e.g. shared-inbox@nhm.ac.uk'), value=data.maintainer_email, error=errors.maintainer_email, classes=['control-medium']) }}
+{{ form.info('Enquiries about this dataset will be sent to this address. If not set, messages will go to the collaborators or creator of the dataset.', inline=False) }}
+
+{{ form.input('maintainer', label=_('Contact name'), id='field-maintainer', placeholder=_('e.g Project Y'), value=data.maintainer, error=errors.maintainer, classes=['control-medium']) }}
+{{ form.info('Name of the person or group receiving dataset enquiries (see above). Optional.', inline=False) }}
 {% endblock %}
 
 {% block custom_fields %}


### PR DESCRIPTION
Allow setting maintainer name and email on datasets. If set, this will take precedence over collaborators and creators for dataset enquiries.