### PR TITLE
Contact email for BII

### DIFF
--- a/ckanext/nhm/lib/mail.py
+++ b/ckanext/nhm/lib/mail.py
@@ -29,7 +29,7 @@ def create_department_email(mail_dict: dict, department: str):
         mail_dict['recipient_email'] = COLLECTION_CONTACTS[department]
     except KeyError:
         # Other/unknown etc., - so don't set recipient email
-        mail_dict['body'] += f'\nDepartment: {department}\n'
+        mail_dict['body'] += f'\nDepartment or team: {department}\n'
     else:
         mail_dict['recipient_name'] = department
         mail_dict['body'] += (

--- a/ckanext/nhm/settings.py
+++ b/ckanext/nhm/settings.py
@@ -17,6 +17,7 @@ COLLECTION_CONTACTS = OrderedDict(
         ('Library & Archives', 'library@nhm.ac.uk'),
         ('Mineral & Planetary Sciences', 'm.rumsey@nhm.ac.uk'),
         ('Vertebrates', 'simon.loader@nhm.ac.uk'),
+        ('Biodiversity Intactness Index', 'biodiversityfuturesexplorer@nhm.ac.uk'),
         ('Data Portal / Other', 'data@nhm.ac.uk'),
     ]
 )

--- a/ckanext/nhm/theme/templates/contact/snippets/form.html
+++ b/ckanext/nhm/theme/templates/contact/snippets/form.html
@@ -27,7 +27,7 @@
 
         {# If this is the collections dataset, still add the department select #}
         {% if package['name'] == 'collection-specimens' %}
-            {{ form.select('department', label=_('Department'), options=h.get_contact_form_department_options(), selected=data.department, error=errors.department, is_required=true) }}
+            {{ form.select('department', label=_('Department or team'), options=h.get_contact_form_department_options(), selected=data.department, error=errors.department, is_required=true) }}
         {% endif %}
 
         <div class="control-group control-medium">
@@ -43,7 +43,7 @@
     {% else %}
 
        {# Add department selection (for non dataset forms)  #}
-       {{ form.select('department', label=_('Department'), options=h.get_contact_form_department_options(), selected=data.department, error=errors.department, is_required=true) }}
+       {{ form.select('department', label=_('Department or team'), options=h.get_contact_form_department_options(), selected=data.department, error=errors.department, is_required=true) }}
 
     {% endif %}
 


### PR DESCRIPTION
Adds biodiversity futures explorer to the list of contacts since we get a lot of emails for the BII datasets.