### PR TITLE
Minor changes to Big Butterfly Count Map page

### DIFF
--- a/ckanext/nhm/theme/assets/scripts/bbcm.js
+++ b/ckanext/nhm/theme/assets/scripts/bbcm.js
@@ -224,9 +224,7 @@ function createPopup(latlng, specs) {
       '<a target="_blank" href="' +
       baseUrl +
       '/object/' +
-      specimen.occurrenceID +
-      '/' +
-      version.toString() +
+      specimen.occurrenceID
       '">View on the Data Portal</a>';
     popupContent += '</div>';
 

--- a/ckanext/nhm/theme/assets/scripts/bbcm.js
+++ b/ckanext/nhm/theme/assets/scripts/bbcm.js
@@ -224,7 +224,7 @@ function createPopup(latlng, specs) {
       '<a target="_blank" href="' +
       baseUrl +
       '/object/' +
-      specimen.occurrenceID
+      specimen.occurrenceID +
       '">View on the Data Portal</a>';
     popupContent += '</div>';
 

--- a/ckanext/nhm/theme/templates/bbcm.html
+++ b/ckanext/nhm/theme/templates/bbcm.html
@@ -15,23 +15,6 @@
 
 {%- block page %}
     {{ super() }}
-    <!-- GA -->
-    <script>
-        (function (w, d, s, l, i) {
-            w[l] = w[l] || [];
-            w[l].push({
-                'gtm.start':
-                    new Date().getTime(), event: 'gtm.js'
-            });
-            var f = d.getElementsByTagName(s)[0],
-                j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : '';
-            j.async = true;
-            j.src =
-                '//www.googletagmanager.com/gtm.js?id=' + i + dl;
-            f.parentNode.insertBefore(j, f);
-        })(window, document, 'script', 'dataLayer', 'GTM-5MDTTC');
-    </script>
-
     <div id="map"></div>
 
     <div id="details">


### PR DESCRIPTION
A couple of minor changes to https://data.nhm.ac.uk/big-butterfly-count-map, specifically:

- remove version from specimen URL links, there's no need for it to be there and it causes a warning about the latest version of the record to be displayed at the top of the record page (this is a separate bug I think but not for this PR).
- remove Google Analytics code from page as we don't need it and GA is dead anyway.