### PR TITLE
Fix footer "legal" link

### DIFF
--- a/ckanext/nhm/theme/templates/footer.html
+++ b/ckanext/nhm/theme/templates/footer.html
@@ -67,7 +67,7 @@
                 href="{{ h.url_for('contact.form') }}">Contact</a>
             </li>
             <li role="presentation" class="dropup">
-                <a href="{{ h.url_for('home.about') }}">Legal</a>
+                <a href="{{ h.url_for('legal.terms') }}">Legal</a>
                 <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button"
                    aria-haspopup="true" aria-expanded="false"
                    aria-label="Legal popup menu">


### PR DESCRIPTION
Copied from the "about" submenu and forgot to change the main link.