### PR TITLE
Clickable links in slickgrid

### DIFF
--- a/ckanext/nhm/theme/assets/scripts/slickgrid.js
+++ b/ckanext/nhm/theme/assets/scripts/slickgrid.js
@@ -109,7 +109,10 @@ var NHMFormatter = function (row, cell, value, columnDef, dataContext) {
 
   // if we don't want to override the functionality, just return the value for the field
   if (value && typeof value === 'string') {
-    value = value.replace(/(https?:\/\/[^ ]+)/g, '<a href="$1">$1</a>');
+    value = value.replace(
+      /(https?:\/\/[^ ]+)/g,
+      '<a href="$1" onclick="window.top.location=this.href">$1</a>',
+    );
   }
   return value;
 };


### PR DESCRIPTION
This enables links in slickgrid tables to be opened in the main window when left-clicked, like the "view" link at the beginning of the row.

This is a very quick fix for this issue. Long-term the recline/slickgrid view needs to be retired entirely.

Closes: #807 