### PR TITLE
IIIF timeout

### DIFF
--- a/ckanext/nhm/lib/utils.py
+++ b/ckanext/nhm/lib/utils.py
@@ -15,7 +15,7 @@ def get_iiif_status():
 
     url = toolkit.config.get('ckanext.iiif.image_server_url')
     try:
-        r = requests.get(url + '/status', timeout=5)
+        r = requests.get(url + '/status', timeout=7)
         if r.ok:
             health['ping'] = True
             response_json = r.json()


### PR DESCRIPTION
Increases the timeout on getting IIIF server status to avoid them both timing out at the same point.

This shouldn't affect any preps work.

Closes: #806