### PR TITLE
Make org field visible to dataset visibility script

### DIFF
--- a/ckanext/nhm/theme/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/nhm/theme/templates/package/snippets/package_basic_fields.html
@@ -25,7 +25,7 @@
     {% set existing_org = data.owner_org or data.group_id %}
 
     {% if organizations_available|length == 1 %}
-        {{ form.hidden('owner_org', value=organizations_available[0].id) }}
+        <input type="hidden" name="owner_org" value="{{ organizations_available[0].id }}" id="field-organizations" />
         {% set dataset_has_organization = True %}
     {% else %}
         <div class="form-group">


### PR DESCRIPTION
Users (including admins) were unable to update the visibility (public/private) of most datasets using the UI because:

- most users only have access to one organisation (nhm), so we generally hide the organisation dropdown field on the dataset edit page
- when the dropdown was hidden, it was rendered with `form.macro()` which does not support the `id` attribute, so it was given a `name` but no `id`
- on dataset edit pages, the [`dataset-visibility.js`](https://github.com/NaturalHistoryMuseum/ckan/blob/main/ckan/public/base/javascript/modules/dataset-visibility.js) script checks if an org has been set by getting the content of the `#field-organizations` node
- if no value is found or set then `#field-private` is disabled
- so if a user only has access to a single org, they couldn't change the dataset visibility

This PR adds an `id` attribute to the hidden field so that it can be loaded by `dataset-visibility.js`.