### PR TITLE
Add link to understanding and sharing the collection page

### DIFF
--- a/ckanext/nhm/routes/legal.py
+++ b/ckanext/nhm/routes/legal.py
@@ -13,7 +13,7 @@ blueprint = Blueprint(name='legal', import_name=__name__)
 @blueprint.route('/privacy')
 def privacy():
     """
-    Redirect to the museum's privacy notice page.
+    Redirect to the Museum's privacy notice page.
     """
     return toolkit.redirect_to('https://www.nhm.ac.uk/about-us/privacy-notice.html')
 
@@ -21,7 +21,7 @@ def privacy():
 @blueprint.route('/accessibility')
 def a11y():
     """
-    Redirect to the museum's accessibility statement page.
+    Redirect to the Museum's accessibility statement page.
     """
     return toolkit.redirect_to(
         'https://www.nhm.ac.uk/about-us/website-accessibility-statement.html'
@@ -43,4 +43,14 @@ def aohc():
     """
     return toolkit.render(
         'legal/aohc.html', {'title': 'Acknowledgement of harmful content'}
+    )
+
+
+@blueprint.route('/understanding-the-collection')
+def usc():
+    """
+    Redirect to the Museum's "Understanding and sharing the collection" page.
+    """
+    return toolkit.redirect_to(
+        'https://www.nhm.ac.uk/about-us/governance/understanding-and-sharing-the-collection.html'
     )

--- a/ckanext/nhm/theme/templates/footer.html
+++ b/ckanext/nhm/theme/templates/footer.html
@@ -79,6 +79,7 @@
                     </li>
                     <li><a href="{{ h.url_for('legal.privacy') }}" class="external">Privacy notice</a></li>
                     <li><a href="{{ h.url_for('legal.a11y') }}" class="external">Website accessibility statement</a></li>
+                    <li><a href="{{ h.url_for('legal.usc') }}" class="external">Understanding and sharing the collection</a></li>
                 </ul>
             </li>
             {% if g.userobj %}

--- a/ckanext/nhm/theme/templates/legal/snippets/menu.html
+++ b/ckanext/nhm/theme/templates/legal/snippets/menu.html
@@ -20,6 +20,11 @@ Displays the legal menu
                         {{ _('Website accessibility statement') }}
                     </a>
                 </li>
+                <li class="nav-item">
+                    <a href="{{ h.url_for('legal.usc') }}" class="external">
+                        {{ _('Understanding and sharing the collection') }}
+                    </a>
+                </li>
             </ul>
         </nav>
     </div>


### PR DESCRIPTION
Adds an external link in the "legal" section (footer and sidebar) to the [Understanding and sharing the collection](https://www.nhm.ac.uk/about-us/governance/understanding-and-sharing-the-collection.html) page on the main Museum website.