### PR TITLE
Configurable gallery resource formats

### DIFF
--- a/ckanext/nhm/plugin.py
+++ b/ckanext/nhm/plugin.py
@@ -399,7 +399,9 @@ class NHMPlugin(SingletonPlugin, toolkit.DefaultDatasetForm):
         """
         return {
             'title': 'DwC associated media',
-            'resource_type': ['dwc', 'csv', 'tsv'],
+            'resource_type': toolkit.config.get(
+                'ckanext.nhm.gallery.resource_types', 'dwc csv tsv'
+            ).split(' '),
             'field_type': ['json'],
         }
 


### PR DESCRIPTION
Makes `resource_types` configurable. Similar to NaturalHistoryMuseum/ckanext-gallery#68 (but not dependent).