### PR TITLE
Andrew/add gbif status

### DIFF
--- a/ckanext/nhm/lib/utils.py
+++ b/ckanext/nhm/lib/utils.py
@@ -4,8 +4,8 @@
 # This file is part of ckanext-nhm
 # Created by the Natural History Museum in London, UK
 
-from datetime import datetime, timedelta, timezone
 from datetime import datetime as dt
+from datetime import timedelta, timezone
 
 import requests
 from cachetools import TTLCache, cached
@@ -87,28 +87,36 @@ def get_ingest_status():
 
 @cached(cache=TTLCache(maxsize=10, ttl=7200))
 def get_gbif_status():
-    gbif_url = toolkit.config.get('ckanext.gbif.dataset_url')
+    gbif_dataset_key = toolkit.config.get('ckanext.gbif.dataset_key')
+    gbif_url = (
+        f'https://api.gbif.org/v1/dataset/{gbif_dataset_key}'
+        if gbif_dataset_key
+        else None
+    )
+
+    status_text = 'unknown'
+    status_type = 'bad'
 
     if gbif_url:
         try:
-            r = requests.get(gbif_url, timeout=7)
+            headers = {'User-Agent': 'NHMUK dataset status: data [at] nhm.ac.uk'}
+            r = requests.get(gbif_url, timeout=7, headers=headers)
             if r.ok:
                 response_json = r.json()
                 modified = response_json.get('modified')
+            else:
+                modified = None
         except Exception as e:
             modified = None
 
-    if modified:
-        modified_datetime = datetime.strptime(str(modified), '%Y-%m-%dT%H:%M:%S.%f%z')
-        now = datetime.now(timezone.utc)
-        time_diff = now - modified_datetime
-        # Check if modified date is within last 7 days
-        if time_diff < timedelta(days=7):
-            status_type = 'good'
-        # Display last modified date
-        status_text = modified_datetime.strftime('%Y-%m-%d')
-    else:
-        status_text = 'unknown'
-        status_type = 'bad'
+        if modified:
+            modified_datetime = dt.strptime(str(modified), '%Y-%m-%dT%H:%M:%S.%f%z')
+            now = dt.now(timezone.utc)
+            time_diff = now - modified_datetime
+            # Check if modified date is within last 7 days
+            if time_diff < timedelta(days=7):
+                status_type = 'good'
+            # Display last modified date
+            status_text = modified_datetime.strftime('%Y-%m-%d')
 
     return status_text, status_type

--- a/ckanext/nhm/plugin.py
+++ b/ckanext/nhm/plugin.py
@@ -646,46 +646,46 @@ class NHMPlugin(SingletonPlugin, toolkit.DefaultDatasetForm):
 
         # overall image server status
         if iiif_health['ping'] and iiif_health['status'] == ':)':
-            status_text = toolkit._('available')
-            status_type = 'good'
+            iiif_status_text = toolkit._('available')
+            iiif_status_type = 'good'
         elif iiif_health['ping'] and iiif_health['status'] != ':)':
-            status_text = toolkit._('available (issues)')
-            status_type = 'ok'
+            iiif_status_text = toolkit._('available (issues)')
+            iiif_status_type = 'ok'
         else:
-            status_text = toolkit._('unavailable')
-            status_type = 'bad'
+            iiif_status_text = toolkit._('unavailable')
+            iiif_status_type = 'bad'
 
         status_reports.append(
             {
                 'label': toolkit._('Image server'),
-                'value': status_text,
+                'value': iiif_status_text,
                 'group': toolkit._('Images'),
                 'help': toolkit._(
                     'The IIIF server provides most of the images in datasets (some are '
                     'externally hosted)'
                 ),
-                'state': status_type,
+                'state': iiif_status_type,
             }
         )
 
         # specimen images
         if iiif_health['ping'] and iiif_health['specimens'] == ':)':
-            status_text = toolkit._('available')
-            status_type = 'good'
+            specimens_status_text = toolkit._('available')
+            specimens_status_type = 'good'
         else:
-            status_text = toolkit._('unavailable')
-            status_type = 'bad'
+            specimens_status_text = toolkit._('unavailable')
+            specimens_status_type = 'bad'
 
         status_reports.append(
             {
                 'label': toolkit._('Specimen images'),
-                'value': status_text,
+                'value': specimens_status_text,
                 'group': toolkit._('Images'),
                 'help': toolkit._(
                     'Specimen images are a specific subset of images used primarily in '
                     'the Collection specimens and Index lots datasets'
                 ),
-                'state': status_type,
+                'state': specimens_status_type,
             }
         )
 
@@ -705,13 +705,13 @@ class NHMPlugin(SingletonPlugin, toolkit.DefaultDatasetForm):
         )
 
         # get the gbif dataset status
-        status_text, status_type = get_gbif_status()
+        gbif_status_text, gbif_status_type = get_gbif_status()
         status_reports.append(
             {
                 'label': toolkit._('GBIF updated'),
-                'value': status_text,
+                'value': gbif_status_text,
                 'help': toolkit._('The last time the GBIF dataset was updated.'),
-                'state': status_type,
+                'state': gbif_status_type,
             }
         )
 


### PR DESCRIPTION
- [x] I have read the [section on commits and pull requests](https://github.com/NaturalHistoryMuseum/ckanext-nhm/blob/main/CONTRIBUTING.md#commits-and-pull-requests) in `CONTRIBUTING.md`


Adds gbif status card to the status page. The card will display the last time the gbif data was updated and will show a warning if the date was over 7 days ago.
