### PR TITLE
Add robots.txt

### DIFF
--- a/ckanext/nhm/theme/public/robots.txt
+++ b/ckanext/nhm/theme/public/robots.txt
@@ -1,0 +1,10 @@
+User-agent: *
+Disallow: /dataset/rate/
+Disallow: /revision/
+Disallow: /dataset/*/history
+Disallow: /api/
+Disallow: /dataset?*
+Disallow: /dataset/*?*
+Disallow: /organi*ation?*
+Disallow: /organi*ation/*?*
+Crawl-Delay: 10


### PR DESCRIPTION
Copies the standard CKAN robots.txt and adds rules to disable crawling of faceted endpoints (dataset and organisation).