### PR TITLE
Search message redirect

### DIFF
--- a/ckanext/nhm/theme/templates/package/resource_read.html
+++ b/ckanext/nhm/theme/templates/package/resource_read.html
@@ -49,7 +49,19 @@
                         {% trans dataset=package.title, url=h.url_for('dataset.read', id=package['name']) %}
                             Source: <a href="{{ url }}">{{ dataset }}</a>{% endtrans %}
                     {% endif %}
-                </div>
+                    {% set query_params = h.get_query_params() %}
+                    {% set multisearch = h.multisearch(query_params) %}
+                    {% set slug = h.nav_slug(query=multisearch, resource_ids=resource['id'] ) %}
+
+                    <div class="alert alert-warning">
+                        {% if h.is_collection_resource_id(resource['id']) %}
+                            <strong>Note:</strong> Please use the
+                            <a href="/search/{{slug}}">new search page</a> for the best experience.
+                        {% else %}
+                            <strong>Note:</strong> You can continue your search on the
+                            <a href="/search/{{slug}}">new search page</a>.
+                        {% endif %}
+                    </div>
             {% endblock %}
         {% block data_preview %}
             {% block resource_view %}

--- a/ckanext/nhm/theme/templates/package/resource_read.html
+++ b/ckanext/nhm/theme/templates/package/resource_read.html
@@ -62,6 +62,7 @@
                             <a href="/search/{{slug}}">new search page</a>.
                         {% endif %}
                     </div>
+                </div>
             {% endblock %}
         {% block data_preview %}
             {% block resource_view %}

--- a/ckanext/nhm/theme/templates/package/resource_read.html
+++ b/ckanext/nhm/theme/templates/package/resource_read.html
@@ -56,10 +56,10 @@
                     <div class="alert alert-warning">
                         {% if h.is_collection_resource_id(resource['id']) %}
                             <strong>Note:</strong> Please use the
-                            <a href="/search/{{slug}}">new search page</a> for the best experience.
+                            <a href="{{ h.url_for('search.view', slug=slug) }}">new search page</a> for the best experience.
                         {% else %}
                             <strong>Note:</strong> You can continue your search on the
-                            <a href="/search/{{slug}}">new search page</a>.
+                            <a href="{{ h.url_for('search.view', slug=slug) }}">new search page</a>.
                         {% endif %}
                     </div>
                 </div>

--- a/ckanext/nhm/theme/templates/package/snippets/resource_view_search.html
+++ b/ckanext/nhm/theme/templates/package/snippets/resource_view_search.html
@@ -13,7 +13,7 @@
     {% if resource.get('name') == 'Specimen records' %}
     <div class="alert alert-warning">
         <strong>Note:</strong> Please use the
-        <a href="/new-search">new search page</a> for the best experience.
+        <a href="/search">new search page</a> for the best experience.
     </div>
     {% endif %}
     <form class="module-content search-form" method="get">

--- a/ckanext/nhm/theme/templates/package/snippets/resource_view_search.html
+++ b/ckanext/nhm/theme/templates/package/snippets/resource_view_search.html
@@ -10,12 +10,6 @@
 {% set filter_pills = h.get_resource_filter_pills(package, resource, resource_view) %}
 
 <div class="resource-view-filter-form row">
-    {% if resource.get('name') == 'Specimen records' %}
-    <div class="alert alert-warning">
-        <strong>Note:</strong> Please use the
-        <a href="/search">new search page</a> for the best experience.
-    </div>
-    {% endif %}
     <form class="module-content search-form" method="get">
 
             <div class="col-md-9 col-sm-9">

--- a/ckanext/nhm/theme/templates/package/snippets/resource_view_search.html
+++ b/ckanext/nhm/theme/templates/package/snippets/resource_view_search.html
@@ -10,6 +10,12 @@
 {% set filter_pills = h.get_resource_filter_pills(package, resource, resource_view) %}
 
 <div class="resource-view-filter-form row">
+    {% if resource.get('name') == 'Specimen records' %}
+    <div class="alert alert-warning">
+        <strong>Note:</strong> Please use the
+        <a href="/new-search">new search page</a> for the best experience.
+    </div>
+    {% endif %}
     <form class="module-content search-form" method="get">
 
             <div class="col-md-9 col-sm-9">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "ckanext-ldap>=3.2.0",
     "ckanext-query-dois>=5.0.0",
     "ckanext-statistics>=3.1.0",
-    "ckanext-versioned-datastore>=6.5.0",
+    "ckanext-versioned-datastore>=6.8.0",
     # this also depends on ckanext-dcat==1.3.0 (see readme)
     "requests",
     "ckantools>=0.4.2",


### PR DESCRIPTION
Adds a message to the old search directing users to the new search. Slug integration allows for search criteria to persist during redirect.
Different message displayed for collections dataset - they get worse performance so message suggests better performance on new search.