### PR TITLE
Tools dropdown +  search nav

### DIFF
--- a/ckanext/nhm/lib/helpers.py
+++ b/ckanext/nhm/lib/helpers.py
@@ -1475,16 +1475,38 @@ def _add_nav_item_class(html_string, classes=None, **kwargs):
     )
 
 
-def build_nav_main(*args):
+def build_nav_main(*menu_items):
     """
     Build a set of menu items. Overrides core CKAN method to add "nav-item" class to li
-    elements.
+    elements and allow endpoint keyword args.
 
-    :param args: tuples of (menu type, title) eg ('login', _('Login'))
+    :param menu_items: tuples of (endpoint_details, title) e.g. ('home.index', _('Home')) or (('search.view', {'slug': 'everything'}), _('Search'))
     :returns: literal - <li class="nav-item"><a href="...">title</a></li>
     """
-    from_core = core_helpers.build_nav_main(*args)
-    return _add_nav_item_class(from_core)
+    current_endpoint = '.'.join(toolkit.get_endpoint())
+    output = ''
+    for item in menu_items:
+        endpoint_details = item[0]
+        if isinstance(endpoint_details, tuple):
+            endpoint_name, endpoint_kwargs = endpoint_details
+        else:
+            endpoint_name = endpoint_details
+            endpoint_kwargs = {}
+        title = item[1]
+        if len(item) == 3 and not toolkit.check_access(item[2]):
+            continue
+        try:
+            endpoint = toolkit.url_for(endpoint_name, **endpoint_kwargs)
+        except BuildError:
+            raise Exception(f'Endpoint {endpoint_name} cannot be found.')
+        active = endpoint_name == current_endpoint
+        link_text = f'<span>{title}</span>'
+        link = core_helpers.link_to(link_text, endpoint).unescape()
+        if active:
+            output += f'<li class="active nav-item">{link}</li>'
+        else:
+            output += f'<li class="nav-item">{link}</li>'
+    return literal(output)
 
 
 def get_specimen_jsonld(uuid, version=None):

--- a/ckanext/nhm/theme/templates/footer.html
+++ b/ckanext/nhm/theme/templates/footer.html
@@ -58,6 +58,21 @@
                     <li><a href="{{ h.url_for('about.credits') }}">Credits</a></li>
                 </ul>
             </li>
+            <li role="presentation" class="dropup">
+                <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button"
+                   aria-haspopup="true" aria-expanded="false"
+                   aria-label="Tools popup menu">
+                    Tools
+                    <span class="caret"></span>
+                </a>
+                <ul class="dropdown-menu">
+                    <li><a href="{{ h.url_for('search.view', slug='specimens') }}">Specimens search</a></li>
+                    <li><a href="{{ h.url_for('search.view') }}">Cross-dataset search</a></li>
+                    <li><a href="{{ h.url_for('status.index') }}">Service status</a></li>
+                    <li><a href="{{ h.url_for('liv.index') }}">Image viewer</a></li>
+                    <li><a href="{{ h.url_for('search.slug_generator') }}">Slugs</a></li>
+                </ul>
+            </li>
             <li role="presentation">
                 <a href="{{ h.url_for('help.index') }}">
                     Help

--- a/ckanext/nhm/theme/templates/header.html
+++ b/ckanext/nhm/theme/templates/header.html
@@ -2,7 +2,7 @@
 
 {# This is the header_site_navigation_tabs block copy-pasted from core, butwith the Organizations link removed #}
 {% block header_site_navigation_tabs %}
-{{ h.build_nav_main(('home.index', _('Home')),('dataset.search', _('Datasets')),('search.view', _('Search')),('contact.form', _('Contact')),('home.about', _('About'))) }}
+{{ h.build_nav_main(('home.index', _('Home')),('dataset.search', _('Datasets')),(('search.view', {'slug': 'specimens'}), _('Search')),('contact.form', _('Contact')),('home.about', _('About'))) }}
 {% endblock %}
 
 {# We do not want a search #}{% block header_site_search %}{% endblock %}


### PR DESCRIPTION
- added tools dropdown (closes #887)
- changed the "Search" nav item in the header so it now directs to `/search/specimens`
- updated `build_nav_main()` helper to facilitate that (now accepts endpoint kwargs)
- these possibly should have been on separate branches but here we are