### PR TITLE
Search redirect banner fix

### DIFF
--- a/ckanext/nhm/theme/templates/package/resource_read.html
+++ b/ckanext/nhm/theme/templates/package/resource_read.html
@@ -52,16 +52,17 @@
                     {% set query_params = h.get_query_params() %}
                     {% set multisearch = h.multisearch(query_params) %}
                     {% set slug = h.nav_slug(query=multisearch, resource_ids=resource['id'] ) %}
-
-                    <div class="alert alert-warning">
-                        {% if h.is_collection_resource_id(resource['id']) %}
-                            <strong>Note:</strong> Please use the
-                            <a href="{{ h.url_for('search.view', slug=slug) }}">new search page</a> for the best experience.
-                        {% else %}
-                            <strong>Note:</strong> You can continue your search on the
-                            <a href="{{ h.url_for('search.view', slug=slug) }}">new search page</a>.
-                        {% endif %}
-                    </div>
+                    {% if res.datastore_active %}
+                        <div class="alert alert-warning">
+                            {% if h.is_collection_resource_id(resource['id']) %}
+                                <strong>Note:</strong> Please use the
+                                <a href="{{ h.url_for('search.view', slug=slug) }}">new search page</a> for the best experience.
+                            {% else %}
+                                <strong>Note:</strong> You can continue your search on the
+                                <a href="{{ h.url_for('search.view', slug=slug) }}">new search page</a>.
+                            {% endif %}
+                        </div>
+                    {% endif %}
                 </div>
             {% endblock %}
         {% block data_preview %}


### PR DESCRIPTION
Only show search redirect banner for datasets where datastore is active. Adds an extra check for this.