### PR TITLE
Only show "best experience" message for specimens

### DIFF
--- a/ckanext/nhm/theme/templates/package/resource_read.html
+++ b/ckanext/nhm/theme/templates/package/resource_read.html
@@ -56,7 +56,7 @@
                         {% set multisearch = h.multisearch(v0_query) %}
                         {% set slug = h.nav_slug(query=multisearch, resource_ids=resource['id'] ) %}
                         <div class="alert alert-warning">
-                            {% if h.is_collection_resource_id(resource['id']) %}
+                            {% if h.get_specimen_resource_id() == resource['id'] %}
                                 <strong>Note:</strong> Please use the
                                 <a href="{{ h.url_for('search.view', slug=slug) }}">new search page</a> for the best experience.
                             {% else %}


### PR DESCRIPTION
I previously thought this made sense for all collections datasets but after using it on a dev instance for a few days (especially with the inclusion of the preps dataset) I've changed my mind.